### PR TITLE
avoid integer overflow when allocating a large block of memory

### DIFF
--- a/src/xviewer-print-preview.c
+++ b/src/xviewer-print-preview.c
@@ -727,7 +727,7 @@ create_surface_from_pixbuf (GdkPixbuf *pixbuf)
     format = CAIRO_FORMAT_ARGB32;
 
   cairo_stride = cairo_format_stride_for_width (format, width);
-  cairo_pixels = g_malloc (height * cairo_stride);
+  cairo_pixels = g_malloc_n (height, cairo_stride);
   surface = cairo_image_surface_create_for_data ((unsigned char *)cairo_pixels,
 						 format,
 						 width, height, cairo_stride);


### PR DESCRIPTION
see https://github.com/mate-desktop/eom/commit/b7849cc5b6e7fd741ef04e334f586266a444ef8a