### PR TITLE
Switch zoom buttons in toolbar

### DIFF
--- a/data/xviewer-toolbar.xml
+++ b/data/xviewer-toolbar.xml
@@ -9,8 +9,8 @@
     <toolitem name="ViewImageGallery"/>
     <toolitem name="ViewFullscreen"/>
     <toolitem name="ViewSlideshow"/>
-    <toolitem name="ViewZoomIn"/>
     <toolitem name="ViewZoomOut"/>
+    <toolitem name="ViewZoomIn"/>
     <toolitem name="ViewZoomNormal"/>
     <toolitem name="ViewZoomFit"/>
     <toolitem name="ViewReload"/>
@@ -27,8 +27,8 @@
     <toolitem name="GoPrevious"/>
     <toolitem name="GoNext"/>
     <separator/>
-    <toolitem name="ViewZoomIn"/>
     <toolitem name="ViewZoomOut"/>
+    <toolitem name="ViewZoomIn"/>
     <toolitem name="ViewZoomNormal"/>
     <toolitem name="ViewZoomFit"/>
     <separator/>

--- a/data/xviewer-ui.xml
+++ b/data/xviewer-ui.xml
@@ -83,8 +83,8 @@
     <toolitem action="GoNext"/>
     <toolitem action="GoLast"/>
     <separator/>
-    <toolitem action="ViewZoomIn"/>
     <toolitem action="ViewZoomOut"/>
+    <toolitem action="ViewZoomIn"/>
     <toolitem action="ViewZoomNormal"/>
     <toolitem action="ViewZoomFit"/>
     <separator/>

--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -2033,11 +2033,11 @@ xviewer_window_create_fullscreen_popup (XviewerWindow *window)
 	box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start (GTK_BOX (main_box), box, FALSE, FALSE, 0);
 
-	action = gtk_action_group_get_action (priv->actions_image, "ViewZoomIn");
+	action = gtk_action_group_get_action (priv->actions_image, "ViewZoomOut");
 	button = create_toolbar_button (action);
 	gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
 
-	action = gtk_action_group_get_action (priv->actions_image, "ViewZoomOut");
+	action = gtk_action_group_get_action (priv->actions_image, "ViewZoomIn");
 	button = create_toolbar_button (action);
 	gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
 
@@ -4483,11 +4483,11 @@ set_action_properties (XviewerWindow      *window,
 	action = gtk_action_group_get_action (image_group, "ImageOpenContainingFolder");
 	g_object_set (action, "short_label", _("Show Folder"), NULL);
 
-	action = gtk_action_group_get_action (image_group, "ViewZoomIn");
-	g_object_set (action, "short_label", _("In"), NULL);
-
 	action = gtk_action_group_get_action (image_group, "ViewZoomOut");
 	g_object_set (action, "short_label", _("Out"), NULL);
+
+	action = gtk_action_group_get_action (image_group, "ViewZoomIn");
+	g_object_set (action, "short_label", _("In"), NULL);
 
 	action = gtk_action_group_get_action (image_group, "ViewZoomNormal");
 	g_object_set (action, "short_label", _("Normal"), NULL);
@@ -4971,11 +4971,11 @@ xviewer_window_construct_ui (XviewerWindow *window)
 	box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start (GTK_BOX (tool_box), box, FALSE, FALSE, 0);
 
-	action = gtk_action_group_get_action (priv->actions_image, "ViewZoomIn");
+	action = gtk_action_group_get_action (priv->actions_image, "ViewZoomOut");
 	button = create_toolbar_button (action);
 	gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
 
-	action = gtk_action_group_get_action (priv->actions_image, "ViewZoomOut");
+	action = gtk_action_group_get_action (priv->actions_image, "ViewZoomIn");
 	button = create_toolbar_button (action);
 	gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
 


### PR DESCRIPTION
Previously: "In" was left, "Out" was right,
now: "Out" is left, "In" is right.

It's the same UI change as in https://github.com/linuxmint/xreader/pull/131