### PR TITLE
Fix build with gnome-desktop-3.28 development

### DIFF
--- a/src/xviewer-thumbnail.c
+++ b/src/xviewer-thumbnail.c
@@ -122,10 +122,16 @@ create_thumbnail_from_pixbuf (XviewerThumbData *data,
 	height = gdk_pixbuf_get_height (pixbuf);
 
 	perc = CLAMP (128.0/(MAX (width, height)), 0, 1);
-
+#if GDK_PIXBUF_CHECK_VERSION(2,36,5)
+	thumb = gdk_pixbuf_scale_simple (pixbuf,
+							   width*perc,
+							   height*perc,
+							   GDK_INTERP_HYPER);
+#else
 	thumb = gnome_desktop_thumbnail_scale_down_pixbuf (pixbuf,
 							   width*perc,
 							   height*perc);
+#endif
 
 	return thumb;
 }
@@ -444,7 +450,11 @@ xviewer_thumbnail_fit_to_size (GdkPixbuf *thumbnail, gint dimension)
 		width  = MAX (width  * factor, 1);
 		height = MAX (height * factor, 1);
 
+#if GDK_PIXBUF_CHECK_VERSION(2,36,5)
+		result_pixbuf = gdk_pixbuf_scale_simple (thumbnail, width, height, GDK_INTERP_HYPER);
+#else
 		result_pixbuf = gnome_desktop_thumbnail_scale_down_pixbuf (thumbnail, width, height);
+#endif
 
 		return result_pixbuf;
 	}

--- a/src/xviewer-thumbnail.h
+++ b/src/xviewer-thumbnail.h
@@ -28,6 +28,12 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include "xviewer-image.h"
 
+#define GDK_PIXBUF_CHECK_VERSION(major, minor, micro) \
+	(GDK_PIXBUF_MAJOR > (major) || \
+	(GDK_PIXBUF_MAJOR == (major) && GDK_PIXBUF_MINOR > (minor)) || \
+	(GDK_PIXBUF_MAJOR == (major) && GDK_PIXBUF_MINOR == (minor) && \
+	 GDK_PIXBUF_MICRO >= (micro)))
+
 G_BEGIN_DECLS
 
 void          xviewer_thumbnail_init        (void);


### PR DESCRIPTION
gnome_desktop_thumbnail has been removed in gnome-desktop-3.28

Based on https://github.com/GNOME/eog/commit/0e7749ba0bfac7e72c19841afcbebb10851533b4