### PR TITLE
Corrected strftime-formatted string.

### DIFF
--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -799,12 +799,12 @@ msgstr "South"
 #. A strftime-formatted string, to display the date the image was taken.
 #: ../src/xviewer-exif-util.c:120 ../src/xviewer-exif-util.c:160
 msgid "%a, %d %B %Y  %X"
-msgstr "a%, %d %B Y%  %X"
+msgstr "%a, %d %B %Y  %X"
 
 #. A strftime-formatted string, to display the date the image was taken, for the case we don't have the time.
 #: ../src/xviewer-exif-util.c:154
 msgid "%a, %d %B %Y"
-msgstr "a%, %d %B Y%"
+msgstr "%a, %d %B %Y"
 
 #. TRANSLATORS: This is the actual focal length used when
 #. the image was taken.


### PR DESCRIPTION
This patch corrects the Date/Time metadata properties panel. It currently displays a%, 29 December Y%.

This occurs when the locale is set to en_CA.