### PR TITLE
Remember Maximized State

### DIFF
--- a/data/org.x.viewer.gschema.xml
+++ b/data/org.x.viewer.gschema.xml
@@ -1,0 +1,141 @@
+<schemalist>
+  <schema gettext-domain="xviewer" id="org.x.viewer" path="/org/x/viewer/">
+    <child name="view" schema="org.x.viewer.view"/>
+    <child name="fullscreen" schema="org.x.viewer.fullscreen"/>
+    <child name="ui" schema="org.x.viewer.ui"/>
+    <child name="plugins" schema="org.x.viewer.plugins"/>
+    <child name="window" schema="org.x.viewer.window"/>
+  </schema>
+  <schema gettext-domain="xviewer" id="org.x.viewer.view" path="/org/x/viewer/view/">
+    <key name="autorotate" type="b">
+      <default>true</default>
+      <summary>Automatic orientation</summary>
+      <description>Whether the image should be rotated automatically based on EXIF orientation.</description>
+    </key>
+    <key name="background-color" type="s">
+	<default>'#000000'</default>
+	<summary>Background Color</summary>
+	<description>The color that is used to fill the area behind the image. If the use-background-color key is not set, the color is determined by the active GTK+ theme instead.</description>
+    </key>
+    <key name="interpolate" type="b">
+      <default>true</default>
+      <summary>Interpolate Image</summary>
+      <description>Whether the image should be interpolated on zoom-out. This leads to better quality but is somewhat slower than non-interpolated images.</description>
+    </key>
+    <key name="extrapolate" type="b">
+      <default>true</default>
+      <summary>Extrapolate Image</summary>
+      <description>Whether the image should be extrapolated on zoom-in. This leads to blurry quality and is somewhat slower than non-extrapolated images.</description>
+    </key>
+    <key name="transparency" enum="org.x.viewer.XviewerTransparencyStyle">
+      <default>'checked'</default>
+      <summary>Transparency indicator</summary>
+      <description>Determines how transparency should be indicated. Valid values are CHECK_PATTERN, COLOR and NONE. If COLOR is chosen, then the trans-color key determines the color value used.</description>
+    </key>
+    <key name="scroll-wheel-zoom" type="b">
+      <default>true</default>
+      <summary>Scroll wheel zoom</summary>
+      <description>Whether the scroll wheel should be used for zooming.</description>
+    </key>
+    <key name="zoom-multiplier" type="d">
+      <default>0.05</default>
+      <summary>Zoom multiplier</summary>
+      <description>The multiplier to be applied when using the mouse scroll wheel  for zooming. This value defines the zooming step used for each scroll  event. For example, 0.05 results in a 5% zoom increment for each  scroll event and 1.00 result in a 100% zoom increment.</description>
+    </key>
+    <key name="trans-color" type="s">
+      <default>'#000000'</default>
+      <summary>Transparency color</summary>
+      <description>If the transparency key has the value COLOR, then this  key determines the color which is used for indicating transparency.</description>
+    </key>
+    <key name="use-background-color" type="b">
+	<default>true</default>
+	<summary>Use a custom background color</summary>
+	<description>If this is active, the color set by the background-color key will be used to fill the area behind the image. If it is not set, the current GTK+ theme will determine the fill color.</description>
+    </key>
+  </schema>
+  <schema gettext-domain="xviewer" id="org.x.viewer.fullscreen" path="/org/x/viewer/fullscreen/">
+    <key name="loop" type="b">
+      <default>true</default>
+      <summary>Loop through the image sequence</summary>
+      <description>Whether the sequence of images should be shown in an endless loop.</description>
+    </key>
+    <key name="upscale" type="b">
+      <default>true</default>
+      <summary>Allow zoom greater than 100% initially</summary>
+      <description>If this is set to FALSE small images will not be stretched to fit into the screen initially.</description>
+    </key>
+    <key name="seconds" type="i">
+      <default>5</default>
+      <summary>Delay in seconds until showing the next image</summary>
+      <description>A value greater than 0 determines the seconds an image stays on screen until the next one is shown automatically. Zero  disables the automatic browsing.</description>
+    </key>
+  </schema>
+  <schema gettext-domain="xviewer" id="org.x.viewer.ui" path="/org/x/viewer/ui/">
+    <key name="toolbar" type="b">
+      <default>true</default>
+      <summary>Show/Hide the window toolbar.</summary>
+    </key>
+    <key name="statusbar" type="b">
+      <default>true</default>
+      <summary>Show/Hide the window statusbar.</summary>
+    </key>
+    <key name="image-gallery" type="b">
+      <default>false</default>
+      <summary>Show/Hide the image gallery pane.</summary>
+    </key>
+    <key name="image-gallery-position" enum="org.x.viewer.XviewerWindowGalleryPos">
+      <default>'bottom'</default>
+      <summary>Image gallery pane position. Set to 0 for bottom;  1 for left; 2 for top; 3 for right.</summary>
+    </key>
+    <key name="image-gallery-resizable" type="b">
+      <default>false</default>
+      <summary>Whether the image gallery pane should be resizable.</summary>
+    </key>
+    <key name="sidebar" type="b">
+      <default>false</default>
+      <summary>Show/Hide the window side pane.</summary>
+    </key>
+    <key name="scroll-buttons" type="b">
+      <default>true</default>
+      <summary>Show/Hide the image gallery pane scroll buttons.</summary>
+    </key>
+    <key name="disable-close-confirmation" type="b">
+	<default>false</default>
+	<summary>Close main window without asking to save changes.</summary>
+    </key>
+    <key name="disable-trash-confirmation" type="b">
+      <default>false</default>
+      <summary>Trash images without asking</summary>
+      <description>If activated, Xviewer won't ask for confirmation when moving images to the trash. It will still ask if any of the files cannot be moved to the trash and would be deleted instead.</description>
+    </key>
+    <key name="filechooser-xdg-fallback" type="b">
+      <default>true</default>
+      <summary>Whether the file chooser should show the user's pictures folder if no images are loaded.</summary>
+      <description>If activated and no image is loaded in the active window, the file chooser will display the user's pictures folder using the XDG special user directories. If deactivated or the pictures folder has not been set up, it will show the current working directory.</description>
+    </key>
+    <key name="propsdialog-netbook-mode" type="b">
+      <default>true</default>
+      <summary>Whether the metadata list in the properties dialog should have its own page.</summary>
+      <description>If activated, the detailed metadata list in the properties dialog will be moved to its own page in the dialog. This should make the dialog more usable on smaller screens, e.g. as used by netbooks. If disabled, the widget will be embedded on the "Metadata" page.</description>
+    </key>
+    <key name="external-editor" type="s">
+      <default>''</default>
+      <summary>External program to use for editing images</summary>
+      <description>The desktop file name (including the ".desktop") of the application to use for editing images (when the "Edit Image" toolbar button is clicked). Set to the empty string to disable this feature.</description>
+    </key>
+  </schema>
+  <schema id="org.x.viewer.plugins" path="/org/x/viewer/plugins/">
+    <key name="active-plugins" type="as">
+      <default>[]</default>
+      <summary>Active plugins</summary>
+      <description>List of active plugins. It doesn't contain the "Location" of the active plugins.  See the .xviewer-plugin file for obtaining the "Location" of a given plugin.</description>
+    </key>
+  </schema>
+  <schema id="org.x.viewer.window" path="/org/x/viewer/window/">
+    <key name="maximized" type="b">
+      <default>true</default>
+      <summary>Maximize Image</summary>
+      <description>Whether the image should be maximized.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/src/xviewer-config-keys.h
+++ b/src/xviewer-config-keys.h
@@ -31,6 +31,7 @@
 #define XVIEWER_CONF_PLUGINS			XVIEWER_CONF_DOMAIN".plugins"
 #define XVIEWER_CONF_UI				XVIEWER_CONF_DOMAIN".ui"
 #define XVIEWER_CONF_VIEW				XVIEWER_CONF_DOMAIN".view"
+#define XVIEWER_CONF_WINDOW				XVIEWER_CONF_DOMAIN".window"
 
 #define XVIEWER_CONF_DESKTOP_LOCKDOWN_SCHEMA	"org.gnome.desktop.lockdown"
 #define XVIEWER_CONF_DESKTOP_CAN_PRINT		"disable-printing"
@@ -46,6 +47,8 @@
 #define XVIEWER_CONF_VIEW_TRANSPARENCY		"transparency"
 #define XVIEWER_CONF_VIEW_TRANS_COLOR		"trans-color"
 #define XVIEWER_CONF_VIEW_USE_BG_COLOR		"use-background-color"
+
+#define XVIEWER_CONF_WINDOW_MAXIMIZED			"maximized"
 
 #define XVIEWER_CONF_FULLSCREEN_LOOP		"loop"
 #define XVIEWER_CONF_FULLSCREEN_UPSCALE		"upscale"


### PR DESCRIPTION
This change fixes issues #31 and #47 

xviewer now preserves the maximized state of the image window from one activation to the next - normal behaviour for most/many applications.

If xviewer is closed with the image window unmaximized then on the next activation the image window will open with the same size as would be the case when using the current master version (the existing behaviour is preserved - this change does not force the unmaximized window position or size)

The change also fixes the odd behaviour of the slide-show as noted in issue #31 - this was that if F5 was pressed to terminate a slide-show when displaying the first image in the slide-show it would return to showing the image maximized or unmaximized as it was before the start of the slide-show. If F5 was pressed as the second or subsequent slide was being displayed it always reverted to showing the image unmaximized. Following this fix the maximized/unmaximized state is preserved when the slide-show is terminated.