### PR TITLE
Key1 behaviour changes

### DIFF
--- a/help/C/shortcuts.page
+++ b/help/C/shortcuts.page
@@ -89,7 +89,7 @@ name</p></td>
          <td><p><key>F5</key></p></td>
     </tr>
     <tr>
-    	<td><p>Actual size</p></td>
+    	<td><p>Actual size (1:1)</p></td>
          <td><p><keyseq><key>Ctrl</key><key>0</key></keyseq> (Zero)</p></td>
     </tr>
     <tr>
@@ -99,6 +99,14 @@ name</p></td>
     <tr>
     	<td><p>Scroll around a large image</p></td>
          <td><p><keyseq><key>Alt</key><key>arrow keys</key></keyseq></p></td>
+    </tr>
+    <tr>
+    	<td><p>Toggle between 1:1 and best fit</p></td>
+         <td><p><key>1</key></p></td>
+    </tr>
+    <tr>
+    	<td><p>Reload image</p></td>
+         <td><p><key>R</key></p></td>
     </tr>
 </table>
 </section>


### PR DESCRIPTION
Fix registration problem when the '1' key is pressed towards the edge of zoomed to fit image that doesn't reach the edge of the window. This is described in more detail in issue #84.

Also causes the '1' key to toggle between 1:1 and zoomed to fit - useful when wanting to check the focus at different parts of the image - can use one finger to press the '1' key and the other hand to move the mouse. Much easier than having to press '1' and 'F' alternately. Again see issue 84 for details.

(Attempt 2)