### PR TITLE
Non auto rotate error

### DIFF
--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -816,9 +816,9 @@ xviewer_image_set_orientation (XviewerImage *img)
 	}
 
 	if (priv->orientation > 4 &&
-	    priv->orientation < 9 &&
+        priv->orientation < 9 &&
         priv->autorotate) {
-		gint tmp;
+        gint tmp;
 
 		tmp = priv->width;
 		priv->width = priv->height;

--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -816,7 +816,8 @@ xviewer_image_set_orientation (XviewerImage *img)
 	}
 
 	if (priv->orientation > 4 &&
-	    priv->orientation < 9) {
+	    priv->orientation < 9 &&
+        priv->autorotate) {
 		gint tmp;
 
 		tmp = priv->width;


### PR DESCRIPTION
Whilst looking at issue #94 I spotted a minor problem if "Edit/Preferences/Automatic orientation" is not checked. In this situation the image that was posted as an example in issue #94 displays still in landscape mode, as expected, but the size shown in the status bar at the bottom of the screen shows the dimensions as if the image had been rotated as defined by the EXIF orientation tags (the tags for both thumbnail and main image are set to 6 to rotate the image 90 deg clockwise).

The fix is to check the autorotate flag before swapping the dimensions.

(Note that this change does not fix issue #94. I can't reproduce the reported error.