### PR TITLE
Add "View Fullscreen" and "View Slideshow" buttons to toolbar

### DIFF
--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -5018,6 +5018,20 @@ xviewer_window_construct_ui (XviewerWindow *window)
 	button = create_toolbar_button (action);
 	gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
 
+	separator = gtk_separator_new (GTK_ORIENTATION_VERTICAL);
+	gtk_box_pack_start (GTK_BOX (tool_box), separator, FALSE, FALSE, 0);
+
+	box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+	gtk_box_pack_start (GTK_BOX (tool_box), box, FALSE, FALSE, 0);
+
+	action = gtk_action_group_get_action (priv->actions_image, "ViewFullscreen");
+	button = create_toolbar_button (action);
+	gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
+
+	action = gtk_action_group_get_action (priv->actions_gallery, "ViewSlideshow");
+	button = create_toolbar_button (action);
+	gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
+
 	gtk_box_pack_start (GTK_BOX (priv->box), priv->toolbar_revealer, FALSE, FALSE, 0);
 
 	gtk_widget_show_all (priv->toolbar_revealer);


### PR DESCRIPTION
Hey, I noticed a common feature in most image viewers, is they have buttons on the toolbar to quickly view the image in Fullscreen mode or run the Slideshow.
The functionality for Fullscreen and Slideshow was already there but accessible only through the Menu.
This quick change aims to mirror the existing functionalities to the toolbar buttons for Fullscreen and Slideshow.

Screenshot attached -

![image](https://user-images.githubusercontent.com/1915009/80289832-fc6e8b00-875e-11ea-81f7-957f4344bf70.png)
 