### PR TITLE
Configure Mouse Wheel

### DIFF
--- a/data/org.x.viewer.gschema.xml.in
+++ b/data/org.x.viewer.gschema.xml.in
@@ -37,6 +37,62 @@
       <summary>Scroll wheel zoom</summary>
       <description>Whether the scroll wheel should be used for zooming.</description>
     </key>
+    <key name="scroll-action" type="i">
+      <default>0</default>
+      <summary>Mouse scroll wheel action</summary>
+      <description>Action for mouse scroll wheel. Values are 0 = zoom,
+          1 = Vertical pan, 2 = horizontal pan, 3 = next/prev image,
+          4 = rotate 90 deg CW or CCW, 5 = no action</description>
+    </key>
+    <key name="shift-scroll-action" type="i">
+      <default>2</default>
+      <summary>Mouse scroll wheel + shift action</summary>
+      <description>Action for mouse scroll wheel. Values are 0 = zoom,
+          1 = Vertical pan, 2 = horizontal pan, 3 = next/prev image,
+          4 = rotate 90 deg CW or CCW, 5 = no action</description>
+    </key>
+    <key name="control-scroll-action" type="i">
+      <default>1</default>
+      <summary>Mouse scroll wheel + ctrl action</summary>
+      <description>Action for mouse scroll wheel. Values are 0 = zoom,
+          1 = Vertical pan, 2 = horizontal pan, 3 = next/prev image,
+          4 = rotate 90 deg CW or CCW, 5 = no action</description>
+    </key>
+    <key name="shift-control-scroll-action" type="i">
+      <default>2</default>
+      <summary>Mouse scroll wheel + shift action</summary>
+      <description>Action for mouse scroll wheel. Values are 0 = zoom,
+          1 = Vertical pan, 2 = horizontal pan, 3 = next/prev image,
+          4 = rotate 90 deg CW or CCW, 5 = no action</description>
+    </key>
+    <key name="tilt-action" type="i">
+      <default>0</default>
+      <summary>Mouse scroll wheel action</summary>
+      <description>Action for mouse scroll wheel. Values are 0 = zoom,
+          1 = Vertical pan, 2 = horizontal pan, 3 = next/prev image,
+          4 = rotate 90 deg CW or CCW, 5 = no action</description>
+    </key>
+    <key name="shift-tilt-action" type="i">
+      <default>1</default>
+      <summary>Mouse scroll wheel + shift action</summary>
+      <description>Action for mouse scroll wheel. Values are 0 = zoom,
+          1 = Vertical pan, 2 = horizontal pan, 3 = next/prev image,
+          4 = rotate 90 deg CW or CCW, 5 = no action</description>
+    </key>
+    <key name="control-tilt-action" type="i">
+      <default>2</default>
+      <summary>Mouse scroll wheel + ctrl action</summary>
+      <description>Action for mouse scroll wheel. Values are 0 = zoom,
+          1 = Vertical pan, 2 = horizontal pan, 3 = next/prev image,
+          4 = rotate 90 deg CW or CCW, 5 = no action</description>
+    </key>
+    <key name="shift-control-tilt-action" type="i">
+      <default>1</default>
+      <summary>Mouse scroll wheel + shift action</summary>
+      <description>Action for mouse scroll wheel. Values are 0 = zoom,
+          1 = Vertical pan, 2 = horizontal pan, 3 = next/prev image,
+          4 = rotate 90 deg CW or CCW, 5 = no action</description>
+    </key>
     <key name="zoom-multiplier" type="d">
       <default>0.05</default>
       <summary>Zoom multiplier</summary>

--- a/data/xviewer-preferences-dialog.ui
+++ b/data/xviewer-preferences-dialog.ui
@@ -84,8 +84,8 @@
                       <object class="GtkLabel" id="label6">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Image Enhancements</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -180,8 +180,8 @@
                       <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Background</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -257,8 +257,8 @@
                       <object class="GtkLabel" id="label8">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Transparent Parts</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -403,8 +403,8 @@
                       <object class="GtkLabel" id="label13">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Image Zoom</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -442,8 +442,8 @@
                       <object class="GtkLabel" id="label15">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Sequence</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -474,9 +474,9 @@
                                   <object class="GtkLabel" id="label36">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
                                     <property name="label" translatable="yes" comments="I18N: This sentence will be displayed above a horizonzal scale to select a number of seconds in xviewer's preferences dialog.">_Time between images:</property>
                                     <property name="use_underline">True</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -563,6 +563,352 @@
               </packing>
             </child>
             <child>
+              <object class="GtkBox" id="Box1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="labelM2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Scroll-wheel</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkGrid" id="Grid1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="labelM4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Scroll</property>
+                        <property name="width_chars">22</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="ScrollTextComboBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="active">0</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Zoom</item>
+                          <item id="1" translatable="yes">Vetical Pan</item>
+                          <item id="2" translatable="yes">Horizontal Pan</item>
+                          <item id="3" translatable="yes">Next/Previous Image</item>
+                          <item id="4" translatable="yes">Rotate 90 degrees</item>
+                          <item id="5" translatable="yes">No Action</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="ScrollShiftTextComboBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="active">0</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Zoom</item>
+                          <item id="1" translatable="yes">Vetical Pan</item>
+                          <item id="2" translatable="yes">Horizontal Pan</item>
+                          <item id="3" translatable="yes">Next/Previous Image</item>
+                          <item id="4" translatable="yes">Rotate 90 degrees</item>
+                          <item id="5" translatable="yes">No Action</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="ScrollCtrlTextComboBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="active">0</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Zoom</item>
+                          <item id="1" translatable="yes">Vetical Pan</item>
+                          <item id="2" translatable="yes">Horizontal Pan</item>
+                          <item id="3" translatable="yes">Next/Previous Image</item>
+                          <item id="4" translatable="yes">Rotate 90 degrees</item>
+                          <item id="5" translatable="yes">No Action</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="ScrollShiftCtrlTextComboBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="active">0</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Zoom</item>
+                          <item id="1" translatable="yes">Vetical Pan</item>
+                          <item id="2" translatable="yes">Horizontal Pan</item>
+                          <item id="3" translatable="yes">Next/Previous Image</item>
+                          <item id="4" translatable="yes">Rotate 90 degrees</item>
+                          <item id="5" translatable="yes">No Action</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="labelM13">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Shift-Scroll</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="labelM15">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Control-Scroll</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="labelM16">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Shift-Control-Scroll</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="labelM3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Tilt-wheel</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkGrid" id="Grid2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkComboBoxText" id="TiltTextComboBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="active">0</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Zoom</item>
+                          <item id="1" translatable="yes">Vetical Pan</item>
+                          <item id="2" translatable="yes">Horizontal Pan</item>
+                          <item id="3" translatable="yes">Next/Previous Image</item>
+                          <item id="4" translatable="yes">Rotate 90 degrees</item>
+                          <item id="5" translatable="yes">No Action</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="TiltShiftTextComboBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="active">0</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Zoom</item>
+                          <item id="1" translatable="yes">Vetical Pan</item>
+                          <item id="2" translatable="yes">Horizontal Pan</item>
+                          <item id="3" translatable="yes">Next/Previous Image</item>
+                          <item id="4" translatable="yes">Rotate 90 degrees</item>
+                          <item id="5" translatable="yes">No Action</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="TiltCtrlTextComboBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="active">0</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Zoom</item>
+                          <item id="1" translatable="yes">Vetical Pan</item>
+                          <item id="2" translatable="yes">Horizontal Pan</item>
+                          <item id="3" translatable="yes">Next/Previous Image</item>
+                          <item id="4" translatable="yes">Rotate 90 degrees</item>
+                          <item id="5" translatable="yes">No Action</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="TiltShiftCtrlTextComboBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="active">0</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Zoom</item>
+                          <item id="1" translatable="yes">Vetical Pan</item>
+                          <item id="2" translatable="yes">Horizontal Pan</item>
+                          <item id="3" translatable="yes">Next/Previous Image</item>
+                          <item id="4" translatable="yes">Rotate 90 degrees</item>
+                          <item id="5" translatable="yes">No Action</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="labelM17">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Tilt</property>
+                        <property name="width_chars">22</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="labelM18">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Shift-Tilt</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="labelM19">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Control-Tilt</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="labelM">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Shift-Control-Tilt</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="labelM1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Mouse</property>
+              </object>
+              <packing>
+                <property name="position">2</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkBox" id="plugin_manager_container">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -582,7 +928,7 @@
                 </child>
               </object>
               <packing>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child type="tab">
@@ -592,7 +938,7 @@
                 <property name="label" translatable="yes">Plugins</property>
               </object>
               <packing>
-                <property name="position">2</property>
+                <property name="position">3</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>

--- a/src/xviewer-config-keys.h
+++ b/src/xviewer-config-keys.h
@@ -42,6 +42,16 @@
 #define XVIEWER_CONF_VIEW_INTERPOLATE		"interpolate"
 #define XVIEWER_CONF_VIEW_EXTRAPOLATE		"extrapolate"
 #define XVIEWER_CONF_VIEW_SCROLL_WHEEL_ZOOM		"scroll-wheel-zoom"
+
+#define XVIEWER_CONF_VIEW_SCROLL_ACTION             "scroll-action"
+#define XVIEWER_CONF_VIEW_SCROLL_SHIFT_ACTION       "shift-scroll-action"
+#define XVIEWER_CONF_VIEW_SCROLL_CTRL_ACTION        "control-scroll-action"
+#define XVIEWER_CONF_VIEW_SCROLL_SHIFT_CTRL_ACTION  "shift-control-scroll-action"
+#define XVIEWER_CONF_VIEW_TILT_ACTION               "tilt-action"
+#define XVIEWER_CONF_VIEW_TILT_SHIFT_ACTION         "shift-tilt-action"
+#define XVIEWER_CONF_VIEW_TILT_CTRL_ACTION          "control-tilt-action"
+#define XVIEWER_CONF_VIEW_TILT_SHIFT_CTRL_ACTION    "shift-control-tilt-action"
+
 #define XVIEWER_CONF_VIEW_ZOOM_MULTIPLIER		"zoom-multiplier"
 #define XVIEWER_CONF_VIEW_AUTOROTATE                "autorotate"
 #define XVIEWER_CONF_VIEW_TRANSPARENCY		"transparency"

--- a/src/xviewer-preferences-dialog.c
+++ b/src/xviewer-preferences-dialog.c
@@ -58,6 +58,15 @@ struct _XviewerPreferencesDialogPrivate {
 	GtkWidget     *seconds_scale;
 
 	GtkWidget     *plugin_manager;
+
+    GtkWidget     *ScrollTextComboBox;
+    GtkWidget     *ScrollShiftTextComboBox;
+    GtkWidget     *ScrollCtrlTextComboBox;
+    GtkWidget     *ScrollShiftCtrlTextComboBox;
+    GtkWidget     *TiltTextComboBox;
+    GtkWidget     *TiltShiftTextComboBox;
+    GtkWidget     *TiltCtrlTextComboBox;
+    GtkWidget     *TiltShiftCtrlTextComboBox;
 };
 
 static GObject *instance = NULL;
@@ -190,6 +199,31 @@ xviewer_preferences_dialog_class_init (XviewerPreferencesDialogClass *klass)
 	gtk_widget_class_bind_template_child_private (widget_class,
 						      XviewerPreferencesDialog,
 						      plugin_manager);
+
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      ScrollTextComboBox);
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      ScrollShiftTextComboBox);
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      ScrollCtrlTextComboBox);
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      ScrollShiftCtrlTextComboBox);
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      TiltTextComboBox);
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      TiltShiftTextComboBox);
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      TiltCtrlTextComboBox);
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      TiltShiftCtrlTextComboBox);
 }
 
 static void
@@ -230,6 +264,32 @@ xviewer_preferences_dialog_init (XviewerPreferencesDialog *pref_dlg)
 				      pd_string_to_rgba_mapping,
 				      pd_rgba_to_string_mapping,
 				      NULL, NULL);
+
+	g_settings_bind (priv->view_settings, XVIEWER_CONF_VIEW_SCROLL_ACTION,
+			 priv->ScrollTextComboBox, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (priv->view_settings, XVIEWER_CONF_VIEW_SCROLL_SHIFT_ACTION,
+			 priv->ScrollShiftTextComboBox, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (priv->view_settings, XVIEWER_CONF_VIEW_SCROLL_CTRL_ACTION,
+			 priv->ScrollCtrlTextComboBox, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (priv->view_settings, XVIEWER_CONF_VIEW_SCROLL_SHIFT_CTRL_ACTION,
+			 priv->ScrollShiftCtrlTextComboBox, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (priv->view_settings, XVIEWER_CONF_VIEW_TILT_ACTION,
+			 priv->TiltTextComboBox, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (priv->view_settings, XVIEWER_CONF_VIEW_TILT_SHIFT_ACTION,
+			 priv->TiltShiftTextComboBox, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (priv->view_settings, XVIEWER_CONF_VIEW_TILT_CTRL_ACTION,
+			 priv->TiltCtrlTextComboBox, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (priv->view_settings, XVIEWER_CONF_VIEW_TILT_SHIFT_CTRL_ACTION,
+			 priv->TiltShiftCtrlTextComboBox, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+
 	g_object_set_data (G_OBJECT (priv->color_radio),
 			   RADIO_VALUE,
 			   GINT_TO_POINTER (XVIEWER_TRANSP_COLOR));

--- a/src/xviewer-scroll-view.c
+++ b/src/xviewer-scroll-view.c
@@ -1957,8 +1957,6 @@ xviewer_scroll_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpoi
             guint state;
             GdkEventKey key_event;
 
-            int new_stderr;
-
             keyval = GDK_KEY_R;
 
             if ((event->direction == GDK_SCROLL_UP) || (event->direction == GDK_SCROLL_LEFT))
@@ -1987,7 +1985,7 @@ xviewer_scroll_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpoi
 
             if (key_event.time - mouse_wheel_time > 400) /* 400 msec debounce of mouse wheel */
             {
-                int old_stderr;
+                int old_stderr, new_stderr;
                                 /* When generating a mouse button event the event structure contains the device
                                    ID for the mouse (see case 3 above) and no Gdk-Warning is generated. The Key
                                    event structure has no device ID member and Gdk reports a warning that:

--- a/src/xviewer-scroll-view.c
+++ b/src/xviewer-scroll-view.c
@@ -3,6 +3,7 @@
 #endif
 
 #include <stdlib.h>
+#include <fcntl.h>
 #include <math.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gdk/gdkkeysyms.h>
@@ -14,6 +15,7 @@
 #include "xviewer-enum-types.h"
 #include "xviewer-scroll-view.h"
 #include "xviewer-debug.h"
+
 #if 0
 #include "uta.h"
 #endif
@@ -121,6 +123,8 @@ struct _XviewerScrollViewPrivate {
 	guint frame_changed_id;
 	GdkPixbuf *pixbuf;
 	cairo_surface_t *surface;
+
+	GSettings           *view_settings;
 
 	/* zoom mode, either ZOOM_MODE_FIT or ZOOM_MODE_FREE */
 	XviewerZoomMode zoom_mode;
@@ -1663,7 +1667,7 @@ display_key_press_event (GtkWidget *widget, GdkEventKey *event, gpointer data)
 
             if ((gdk_pixbuf_get_width (priv->pixbuf) <= allocation.width)
                 && (gdk_pixbuf_get_height (priv->pixbuf) <= allocation.height))
-                    zoom = 1.0;                         // the 1:1 image fits in the window
+                    zoom = 1.0;                         /* the 1:1 image fits in the window */
             else
             {
                 if (DOUBLE_EQUAL(priv->zoom, 1.0))
@@ -1672,8 +1676,8 @@ display_key_press_event (GtkWidget *widget, GdkEventKey *event, gpointer data)
                     zoom = 1.0;
             }
 
-                            // the following two statements are necessary otherwise if the 1:1 image
-                            //  is dragged the alignment is thrown out
+                            /* the following two statements are necessary otherwise if the 1:1 image
+                               is dragged the alignment is thrown out */
             if (DOUBLE_EQUAL(priv->zoom,zoom_for_fit))
             {
                 priv->xofs = 0;
@@ -1795,11 +1799,7 @@ xviewer_scroll_view_button_release_event (GtkWidget *widget, GdkEventButton *eve
 	return TRUE;
 }
 
-/* Scroll event handler for the image view.  We zoom with an event without
- * modifiers rather than scroll; we use the Shift modifier to scroll.
- * Rationale: images are not primarily vertical, and in XVIEWER you scan scroll by
- * dragging the image with button 1 anyways.
- */
+/* Scroll event handler for the image view */
 static gboolean
 xviewer_scroll_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpointer data)
 {
@@ -1807,9 +1807,18 @@ xviewer_scroll_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpoi
 	XviewerScrollViewPrivate *priv;
 	double zoom_factor;
 	int xofs, yofs;
+    int button_combination;         /* 0 = scroll, 1 = scroll + shift, 2 = scroll + ctrl, 3 = scroll + shift + ctrl
+                                        4..7 as 0..3 but for tilt wheel */
+    int action;                     /* 0 = zoom, 1 = vertical pan, 2 = horizontal pan, 3 = next/prev image */
+    static guint32 mouse_wheel_time = 0;     /* used to debounce the mouse wheel (scroll and tilt)
+                                                         when used for next/previous image or rotate image */
+
+
 
 	view = XVIEWER_SCROLL_VIEW (data);
 	priv = view->priv;
+
+	priv->view_settings = g_settings_new (XVIEWER_CONF_VIEW);
 
 	/* Compute zoom factor and scrolling offsets; we'll only use either of them */
 	/* same as in gtkscrolledwindow.c */
@@ -1817,52 +1826,197 @@ xviewer_scroll_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpoi
 	yofs = gtk_adjustment_get_page_increment (priv->vadj) / 2;
 
 	switch (event->direction) {
-	case GDK_SCROLL_UP:
-		zoom_factor = priv->zoom_multiplier;
-		xofs = 0;
-		yofs = -yofs;
-		break;
+	    case GDK_SCROLL_UP:
+            button_combination = 0;     /* scroll wheel */
+		    break;
 
-	case GDK_SCROLL_LEFT:
-		zoom_factor = 1.0 / priv->zoom_multiplier;
-		xofs = -xofs;
-		yofs = 0;
-		break;
+	    case GDK_SCROLL_LEFT:
+            button_combination = 4;     /* tilt wheel */
+		    break;
 
-	case GDK_SCROLL_DOWN:
-		zoom_factor = 1.0 / priv->zoom_multiplier;
-		xofs = 0;
-		yofs = yofs;
-		break;
+	    case GDK_SCROLL_DOWN:
+            button_combination = 0;     /* scroll wheel */
+		    break;
 
-	case GDK_SCROLL_RIGHT:
-		zoom_factor = priv->zoom_multiplier;
-		xofs = xofs;
-		yofs = 0;
-		break;
+	    case GDK_SCROLL_RIGHT:
+            button_combination = 4;     /* tilt wheel */
+		    break;
 
-	default:
-		g_assert_not_reached ();
-		return FALSE;
+	    default:
+		    g_assert_not_reached ();
+		    return FALSE;
 	}
 
-        if (priv->scroll_wheel_zoom) {
-		if (event->state & GDK_SHIFT_MASK)
-			scroll_by (view, yofs, xofs);
-		else if (event->state & GDK_CONTROL_MASK)
+    if (event->state & GDK_SHIFT_MASK)
+        button_combination++;
+
+    if (event->state & GDK_CONTROL_MASK)
+        button_combination += 2;
+
+    switch (button_combination)
+    {
+        case 0:
+            action = g_settings_get_int(priv->view_settings,
+				     XVIEWER_CONF_VIEW_SCROLL_ACTION);
+            break;
+        case 1:
+            action = g_settings_get_int(priv->view_settings,
+				     XVIEWER_CONF_VIEW_SCROLL_SHIFT_ACTION);
+            break;
+        case 2:
+            action = g_settings_get_int(priv->view_settings,
+				     XVIEWER_CONF_VIEW_SCROLL_CTRL_ACTION);
+            break;
+        case 3:
+            action = g_settings_get_int(priv->view_settings,
+				     XVIEWER_CONF_VIEW_SCROLL_SHIFT_CTRL_ACTION);
+            break;
+        case 4:
+            action = g_settings_get_int(priv->view_settings,
+				     XVIEWER_CONF_VIEW_TILT_ACTION);
+            break;
+        case 5:
+            action = g_settings_get_int(priv->view_settings,
+				     XVIEWER_CONF_VIEW_TILT_SHIFT_ACTION);
+            break;
+        case 6:
+            action = g_settings_get_int(priv->view_settings,
+				     XVIEWER_CONF_VIEW_TILT_CTRL_ACTION);
+            break;
+        case 7:
+            action = g_settings_get_int(priv->view_settings,
+				     XVIEWER_CONF_VIEW_TILT_SHIFT_CTRL_ACTION);
+            break;
+    }
+
+    switch (action)
+    {
+        case 0:                             /* zoom */
+            if ((event->direction == GDK_SCROLL_UP) || (event->direction == GDK_SCROLL_RIGHT))
+                zoom_factor = priv->zoom_multiplier;
+            else
+                zoom_factor = 1.0 / priv->zoom_multiplier;
+            set_zoom (view, priv->zoom * zoom_factor, TRUE, event->x, event->y);
+            break;
+
+        case 1:                             /* vertical pan */
+            xofs = 0;
+            if ((event->direction == GDK_SCROLL_UP) || (event->direction == GDK_SCROLL_RIGHT))
+                yofs = -yofs;
+            else
+                yofs = yofs;
 			scroll_by (view, xofs, yofs);
-		else
-			set_zoom (view, priv->zoom * zoom_factor,
-				  TRUE, event->x, event->y);
-	} else {
-		if (event->state & GDK_SHIFT_MASK)
-			scroll_by (view, yofs, xofs);
-		else if (event->state & GDK_CONTROL_MASK)
-			set_zoom (view, priv->zoom * zoom_factor,
-				  TRUE, event->x, event->y);
-		else
+            break;
+
+        case 2:                             /* horizontal pan */
+            yofs = 0;
+            if ((event->direction == GDK_SCROLL_DOWN) || (event->direction == GDK_SCROLL_RIGHT))
+                xofs = xofs;
+            else
+                xofs = -xofs;
 			scroll_by (view, xofs, yofs);
+            break;
+
+        case 3:                             /* move to next/prev image */
+        {
+            GdkEventButton button_event;
+
+            button_event.type = GDK_BUTTON_PRESS;
+            button_event.window = gtk_widget_get_window(widget);
+            button_event.send_event = TRUE;
+            button_event.time = g_get_monotonic_time() / 1000;
+            button_event.x = 0.0;         /* coordinate parameters are irrelevant for this button press */
+            button_event.y = 0.0;
+            button_event.axes = NULL;
+            button_event.state = 0;
+            if ((event->direction == GDK_SCROLL_UP) || (event->direction == GDK_SCROLL_LEFT))
+                button_event.button = 8;
+            else
+                button_event.button = 9;
+
+            button_event.device = event->device;
+            button_event.x_root = 0.0;
+            button_event.y_root = 0.0;
+
+
+            if (button_event.time - mouse_wheel_time > 400) /* 400 msec debounce of mouse wheel */
+            {
+                gtk_main_do_event((GdkEvent *)&button_event);
+
+                mouse_wheel_time = button_event.time;
+            }
+
+            break;
         }
+
+        case 4:                             /* Rotate image 90 CW or CCW */
+        {
+           GdkKeymapKey* keys;
+            gint n_keys;
+            guint keyval;
+            guint state;
+            GdkEventKey key_event;
+
+            int old_stderr, new_stderr;
+
+            keyval = GDK_KEY_R;
+
+            if ((event->direction == GDK_SCROLL_UP) || (event->direction == GDK_SCROLL_LEFT))
+                state = GDK_CONTROL_MASK + GDK_SHIFT_MASK;
+            else
+                state = GDK_CONTROL_MASK;
+
+            gdk_keymap_get_entries_for_keyval(gdk_keymap_get_for_display (gtk_widget_get_display(widget)),
+                                          keyval,
+                                          &keys,
+                                          &n_keys);
+
+ 
+
+            key_event.type = GDK_KEY_PRESS;
+            key_event.window = gtk_widget_get_window(widget);
+            key_event.send_event = TRUE;
+            key_event.time = g_get_monotonic_time() / 1000;
+            key_event.state = state;
+            key_event.keyval = keyval;
+            key_event.length = 0;
+            key_event.string = NULL;
+            key_event.hardware_keycode = keys[0].keycode;
+            key_event.group = keys[0].group;
+            key_event.is_modifier = FALSE;
+
+            if (key_event.time - mouse_wheel_time > 400) /* 400 msec debounce of mouse wheel */
+            {
+                                /* When generating a mouse button event the event structure contains the device
+                                   ID for the mouse (see case 3 above) and no Gdk-Warning is generated. The Key
+                                   event structure has no device ID member and Gdk reports a warning that:
+
+                                  "Event with type 8 not holding a GdkDevice. It is most likely synthesized
+                                   outside Gdk/GTK+"
+
+                                   The following code therefore temporarily suppresses stderr to avoid showing
+                                   this warning when (given the Gdk implementation) it is expected - and untidy! */
+
+                fflush(stderr);
+                old_stderr = dup(2);
+                new_stderr = open("/dev/null", O_WRONLY);
+                dup2(new_stderr, 2);
+                close(new_stderr);
+
+                gtk_main_do_event((GdkEvent *)&key_event);
+
+                fflush(stderr);             /* restore normal stderr output */
+                dup2(old_stderr, 2);
+                close(old_stderr);
+
+                mouse_wheel_time = key_event.time;
+            }
+            break;
+        }
+
+
+        /* case 5 = no action */
+    }
 
 	return TRUE;
 }

--- a/src/xviewer-scroll-view.c
+++ b/src/xviewer-scroll-view.c
@@ -1957,7 +1957,7 @@ xviewer_scroll_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpoi
             guint state;
             GdkEventKey key_event;
 
-            int old_stderr, new_stderr;
+            int new_stderr;
 
             keyval = GDK_KEY_R;
 
@@ -1987,6 +1987,7 @@ xviewer_scroll_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpoi
 
             if (key_event.time - mouse_wheel_time > 400) /* 400 msec debounce of mouse wheel */
             {
+                int old_stderr;
                                 /* When generating a mouse button event the event structure contains the device
                                    ID for the mouse (see case 3 above) and no Gdk-Warning is generated. The Key
                                    event structure has no device ID member and Gdk reports a warning that:


### PR DESCRIPTION
These changes address issues #17 and #59 by adding the feature requested in issue #17 and making the mouse scroll and tilt configurable.
Whilst the existing version of xviewer did allow the user to pan the image using scroll in conjunction with Shift and Ctrl this was not obvious without looking at the program code.
The new code adds a tab to the user preferences dialog that allows the user to select the actions for:
Scroll, Scroll + Shift, Scroll + Ctrl, Scroll + Shift + Ctrl
Tilt, Tilt + Shift, Tilt + Ctrl, Tilt + Shift + Ctrl
The actions that can be assigned to the 8 key combinations listed above are:
Zoom
Vertical pan
Horizontal pan
Move to next/previous image
Rotate 90 degrees
No action
("No action" has been included to cover the situation where a user is habituated to use a particular mouse-wheel action in another program - if this action is not in the above list it may be better for the program to take no action, rather than do something that then needs to be undone. It also doesn't take any code to implement "No action")
The default actions for the mouse-wheel in this new version replicate the settings in the current master, so there will be no unexpected behaviour for users.
Adding further actions that are initiated by a single keypress would be an easy task.

(Attempt 2 at this pull request after problems caused, I think, by the previous attempt using a fork from before the change to Mint 20)