### PR TITLE
Delete Dialog Focus

### DIFF
--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -3451,9 +3451,11 @@ show_force_image_delete_confirm_dialog (XviewerWindow *window,
 	if (n_images == 1) {
 		gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Cancel"), GTK_RESPONSE_CANCEL);
 		delete_button = gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Delete"), GTK_RESPONSE_OK);
+        gtk_style_context_add_class (gtk_widget_get_style_context (delete_button), GTK_STYLE_CLASS_DESTRUCTIVE_ACTION);
 	} else {
 		gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Cancel"), GTK_RESPONSE_CANCEL);
 		delete_button = gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Yes")   , GTK_RESPONSE_OK);
+        gtk_style_context_add_class (gtk_widget_get_style_context (delete_button), GTK_STYLE_CLASS_DESTRUCTIVE_ACTION);
 	}
 
 	/* add 'dont ask again' button */

--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -3412,6 +3412,7 @@ show_force_image_delete_confirm_dialog (XviewerWindow *window,
 	gchar     *prompt;
 	guint      n_images;
 	gint       response;
+    GtkWidget *delete_button;
 
 	/* assume agreement, if the user doesn't want to be asked and deletion is available */
 	if (dont_ask_again_force_delete)
@@ -3449,10 +3450,10 @@ show_force_image_delete_confirm_dialog (XviewerWindow *window,
 	/* add buttons to the dialog */
 	if (n_images == 1) {
 		gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Cancel"), GTK_RESPONSE_CANCEL);
-		gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Delete"), GTK_RESPONSE_OK);
+		delete_button = gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Delete"), GTK_RESPONSE_OK);
 	} else {
 		gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Cancel"), GTK_RESPONSE_CANCEL);
-		gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Yes")   , GTK_RESPONSE_OK);
+		delete_button = gtk_dialog_add_button (GTK_DIALOG (dialog), _("_Yes")   , GTK_RESPONSE_OK);
 	}
 
 	/* add 'dont ask again' button */
@@ -3467,6 +3468,7 @@ show_force_image_delete_confirm_dialog (XviewerWindow *window,
 			  TRUE,
 			  0);
 
+    gtk_widget_grab_focus (delete_button);
 	/* show dialog and get user response */
 	gtk_widget_show_all (dialog);
 	response = gtk_dialog_run (GTK_DIALOG (dialog));


### PR DESCRIPTION
This PR addresses issue #99. It sets the focus on the "Delete" button rather than leaving the focus on the option of not asking again.