### PR TITLE
JPG over 16384 pixels

### DIFF
--- a/src/xviewer-scroll-view.c
+++ b/src/xviewer-scroll-view.c
@@ -243,9 +243,7 @@ create_surface_from_pixbuf (XviewerScrollView *view, GdkPixbuf *pixbuf)
         size_invalid = TRUE;
     }
 
-	surface = gdk_window_create_similar_surface (gtk_widget_get_window (view->priv->display),
-						     CAIRO_CONTENT_COLOR | CAIRO_CONTENT_ALPHA,
-						     w, h);
+    surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, w, h);
 
 	if (size_invalid) {
 		return surface;


### PR DESCRIPTION
This change addresses issue #118 where jpgs with dimensions over 16384 pixels don't display right-hand and bottom portions for pixels 16384 upwards correctly. TIF files worked correctly - not sure why.

The problem occurs in xviewer-scroll-view.c/create_surface_from_pixbuf()

Adding the following to the end of the function created a file that, when displayed, showed transparent pixels for those to the right of pixel 16383.

cairo_surface_write_to_png (surface, "test.png");

pix displayed these files correctly so initially I replace the code of the problem function with code from pix. This fixed the problem but the code was more more extensive.

The solution was to change the creation of the surface from:

`	surface = gdk_window_create_similar_surface (gtk_widget_get_window (view->priv->display),
						     CAIRO_CONTENT_COLOR | CAIRO_CONTENT_ALPHA,
						     w, h);
`
by:

`    surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, w, h);`

I have tested this with a file of 16992x288 pixels in jpg, tif, png (with a transparent area) and 24-bit bmp.

