### PR TITLE
Spacebar Optionally Pauses Slideshow (Fixes: https://github.com/linuxmint/xviewer/issues/16)

### DIFF
--- a/data/org.x.viewer.gschema.xml.in
+++ b/data/org.x.viewer.gschema.xml.in
@@ -125,6 +125,11 @@
       <summary>Delay in seconds until showing the next image</summary>
       <description>A value greater than 0 determines the seconds an image stays on screen until the next one is shown automatically. Zero  disables the automatic browsing.</description>
     </key>
+    <key name="space-pause" type="b">
+      <default>false</default>
+      <summary>Spacebar pauses and resumes slideshows</summary>
+      <description>Whether the spacebar should pause and resume slideshows.</description>
+    </key>
   </schema>
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.x.viewer.ui" path="/org/x/viewer/ui/">
     <key name="toolbar" type="b">

--- a/data/xviewer-preferences-dialog.ui
+++ b/data/xviewer-preferences-dialog.ui
@@ -542,6 +542,43 @@
                         <property name="position">3</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkLabel" id="label_pause_resume">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Pause/Resume</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">16</property>
+                        <child>
+                          <object class="GtkCheckButton" id="pause_resume_check">
+                            <property name="label" translatable="yes">Spacebar pauses/resumes slideshows</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/src/xviewer-config-keys.h
+++ b/src/xviewer-config-keys.h
@@ -60,9 +60,10 @@
 
 #define XVIEWER_CONF_WINDOW_MAXIMIZED			"maximized"
 
-#define XVIEWER_CONF_FULLSCREEN_LOOP		"loop"
-#define XVIEWER_CONF_FULLSCREEN_UPSCALE		"upscale"
-#define XVIEWER_CONF_FULLSCREEN_SECONDS		"seconds"
+#define XVIEWER_CONF_FULLSCREEN_LOOP		    "loop"
+#define XVIEWER_CONF_FULLSCREEN_UPSCALE		    "upscale"
+#define XVIEWER_CONF_FULLSCREEN_SECONDS		    "seconds"
+#define XVIEWER_CONF_FULLSCREEN_SPACEBAR_PAUSE  "space-pause"
 
 #define XVIEWER_CONF_UI_TOOLBAR			"toolbar"
 #define XVIEWER_CONF_UI_STATUSBAR			"statusbar"

--- a/src/xviewer-preferences-dialog.c
+++ b/src/xviewer-preferences-dialog.c
@@ -56,6 +56,7 @@ struct _XviewerPreferencesDialogPrivate {
 	GtkWidget     *upscale_check;
 	GtkWidget     *loop_check;
 	GtkWidget     *seconds_scale;
+    GtkWidget     *pause_resume_check;
 
 	GtkWidget     *plugin_manager;
 
@@ -195,6 +196,9 @@ xviewer_preferences_dialog_class_init (XviewerPreferencesDialogClass *klass)
 	gtk_widget_class_bind_template_child_private (widget_class,
 						      XviewerPreferencesDialog,
 						      seconds_scale);
+	gtk_widget_class_bind_template_child_private (widget_class,
+						      XviewerPreferencesDialog,
+						      pause_resume_check);
 
 	gtk_widget_class_bind_template_child_private (widget_class,
 						      XviewerPreferencesDialog,
@@ -352,6 +356,10 @@ xviewer_preferences_dialog_init (XviewerPreferencesDialog *pref_dlg)
 
 	g_settings_bind (priv->fullscreen_settings, XVIEWER_CONF_FULLSCREEN_LOOP,
 			 priv->loop_check, "active",
+			 G_SETTINGS_BIND_DEFAULT);
+
+	g_settings_bind (priv->fullscreen_settings, XVIEWER_CONF_FULLSCREEN_SPACEBAR_PAUSE,
+			 priv->pause_resume_check, "active",
 			 G_SETTINGS_BIND_DEFAULT);
 
 	scale_adjustment = gtk_range_get_adjustment (GTK_RANGE (priv->seconds_scale));


### PR DESCRIPTION
These changes address issue #16. They add an option to the Preferences Slideshow tab to cause the spacebar to pause/resume a slideshow (instead of moving to the next image). By default the option is disabled thereby preserving the current behaviour.

The right-arrow and PgDn keys still function as before to allow the user to move to the next image.

When a slideshow is not active the spacebar still behaves as it has up to now.
