### PR TITLE
Open svgz files (Fixes: https://github.com/linuxmint/xviewer/issues/128)

### DIFF
--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -763,8 +763,8 @@ xviewer_image_get_file_info (XviewerImage *img,
                *mime_type = mime_type_by_extn;
             else
             {
-                if ((strcmp(*mime_type,"application/gzip") == 0) &&
-                    (strcmp(mime_type_by_extn,"image/svg+xml-compressed") == 0))
+                if ((strstr(*mime_type,"application/") == *mime_type) &&
+                    (strstr(mime_type_by_extn,"image/") == mime_type_by_extn))
                     *mime_type = g_strdup(mime_type_by_extn);
             }
 

--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -718,11 +718,11 @@ xviewer_image_get_file_info (XviewerImage *img,
             gint bytes_read;
             char *mime_type_by_extn;
 
-            input_stream = g_file_read(img->priv->file,
+            input_stream = g_file_read (img->priv->file,
                                        NULL, error);
             if (input_stream)
             {
-                bytes_read = g_input_stream_read(G_INPUT_STREAM (input_stream),
+                bytes_read = g_input_stream_read (G_INPUT_STREAM (input_stream),
                                                  ip_buffer,
                                                  BUFFER_SIZE,
                                                  NULL, error);
@@ -736,7 +736,7 @@ xviewer_image_get_file_info (XviewerImage *img,
                         if ((magic_type_ids[i].offset + magic_type_ids[i].length) <= bytes_read)
                             if (! memcmp (ip_buffer + magic_type_ids[i].offset, magic_type_ids[i].id_bytes, magic_type_ids[i].length))
                                 {
-                                    *mime_type =  g_strdup(magic_type_ids[i].mime_type_str);
+                                    *mime_type =  g_strdup (magic_type_ids[i].mime_type_str);
                                     file_type_unknown = FALSE;
                                     break;
                                 }
@@ -750,9 +750,9 @@ xviewer_image_get_file_info (XviewerImage *img,
                     content_type = g_content_type_guess (NULL, ip_buffer, bytes_read, &result_uncertain);
                     if (content_type != NULL)
                     {
-                        *mime_type =  g_strdup(content_type);
+                        *mime_type =  g_strdup (content_type);
                         file_type_unknown = FALSE;
-                        g_free(content_type);
+                        g_free (content_type);
                     }
                 }
             }
@@ -760,15 +760,15 @@ xviewer_image_get_file_info (XviewerImage *img,
             mime_type_by_extn = g_strdup (g_file_info_get_content_type (file_info));
 
             if (file_type_unknown)
-               *mime_type = mime_type_by_extn;
+               *mime_type = g_strdup (mime_type_by_extn);
             else
             {
-                if ((strstr(*mime_type,"application/") == *mime_type) &&
-                    (strstr(mime_type_by_extn,"image/") == mime_type_by_extn))
-                    *mime_type = g_strdup(mime_type_by_extn);
+                if ((strstr (*mime_type,"application/") == *mime_type) &&
+                    (strstr (mime_type_by_extn,"image/") == mime_type_by_extn))
+                    *mime_type = g_strdup (mime_type_by_extn);
             }
 
-            g_free(mime_type_by_extn);
+            g_free (mime_type_by_extn);
         }
 		g_object_unref (file_info);
 	}


### PR DESCRIPTION
PR #123 to open files that had the wrong extensions caused xviewer to stop opening .svgz files.

PR #123 changed the order of determining the file type to be:
  1 Check the 'magic numbers'
  2 If not determined by the 'magic numbers' method call g_content_type_guess() to try to determine the file type from its contents
  3 If the file type isn't determined by steps 1 and 2 call g_file_info_get_content_type() to determine the type from the extension

The problem for .svgz files is that step 2 recognizes the file mime type as application/gzip. As the file type has been recognised step 3 (which would return image/svg+xml-compressed) is omitted.

The change is to call g_file_info_get_content_type() whether or not steps 1 and 2 have identified the file type. Then if step 2 recognized the type as application/gzip and step 3 recognizes it as image/svg+xml-compressed return a type of image/svg+xml-compressed since this is the best guess as to the file type.