### PR TITLE
[Next] Fix issue 24

### DIFF
--- a/src/xviewer-scroll-view.c
+++ b/src/xviewer-scroll-view.c
@@ -2239,7 +2239,12 @@ display_draw (GtkWidget *widget, cairo_t *cr, gpointer data)
 			if ((is_zoomed_in (view) && priv->interp_type_in != CAIRO_FILTER_NEAREST) ||
 				(is_zoomed_out (view) && priv->interp_type_out != CAIRO_FILTER_NEAREST)) {
 				// CAIRO_FILTER_GOOD is too slow during zoom changes, so use CAIRO_FILTER_BILINEAR instead
-				interp_type = CAIRO_FILTER_BILINEAR;
+				/* interp_type = CAIRO_FILTER_BILINEAR; */
+                interp_type = CAIRO_FILTER_GOOD;    /* revert to using CAIRO_FILTER_GOOD to fix issue #24.
+                                                        Using CAIRO_FILTER_BILINEAR results in a blank display
+                                                        for the affected images - it also aeems to be slower than
+                                                        CAIRO_FILTER_GOOD (as of 26.9.2021) in contradiction to the
+                                                        earlier statement. */
 			}
 			else {
 				interp_type = CAIRO_FILTER_NEAREST;


### PR DESCRIPTION
This PR fixes the problem reported in issue #24 on 13.9.2021 (I believe the original problem reported in this issue is no longer a problem)

The image uploaded by rmast would only display correctly if xviewer started un-maximized - but even then any attempt to zoom the image resulted (for me) in just a plain white image. Similar to what rmast reported.

The solution appears to be to use CAIRO_FILTER_GOOD instead of CAIRO_FILTER_BILINEAR in function xviewer-scroll-view.c/display_draw(). This not only appears to resolve the issue but also appears to run faster (contrary to the previous comment in that section of the source  code). I zoomed down to 2% and timed how long I had to press the + key to reach 2000% zoom. I also timed the reverse process by holding the - key.  I did this for the file uploaded by rmast and for a number of other files including one of 6016x8000 pixels in jpg, bmp, png and tif formats. The format seemed to make very little, if any, difference but the BILINEAR filter consistently took approximately 127% of the time taken by the GOOD filter.