### PR TITLE
Reflect External Changes - Fixes Issue 151

### DIFF
--- a/src/xviewer-list-store.c
+++ b/src/xviewer-list-store.c
@@ -645,6 +645,8 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
 		} else if (file_type == G_FILE_TYPE_REGULAR && !singleton_list) {
 			xviewer_list_store_append_image_from_file (store, file);
 
+
+			g_object_unref (file);
 			file = g_file_get_parent (file);
 			file_info = g_file_query_info (file,
 						       G_FILE_ATTRIBUTE_STANDARD_TYPE,
@@ -669,7 +671,7 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
                 dir_iter = directory_list;
 
                 while ((dir_iter != NULL) && name_not_found) {
-                    if (strcmp(dir_iter->data, directory_name) == 0)
+                    if (g_strcmp0 (dir_iter->data, directory_name) == 0)
                         name_not_found = FALSE;
                     dir_iter = dir_iter->next;
                 }
@@ -679,19 +681,14 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
                     xviewer_list_store_set_directory_callbacks (store, file, file_type);
                 }
 
-                g_free(directory_name);
+                g_free (directory_name);
+			    g_object_unref (file);
            }
 		}
 	}
 
-    if (directory_list != NULL) {
-        dir_iter = directory_list;
-        while (dir_iter != NULL) {
-            g_free(dir_iter->data);
-            dir_iter = dir_iter->next;
-        }
-        g_list_free(directory_list);
-    }
+    if (directory_list != NULL)
+        g_list_free_full(directory_list, g_free);
 
 	if (initial_file &&
 	    is_file_in_list_store_file (store, initial_file, &iter)) {

--- a/src/xviewer-list-store.c
+++ b/src/xviewer-list-store.c
@@ -485,14 +485,14 @@ directory_visit (GFile *directory,
 	}
 }
 
+/* Set up callbacks for changes to files in a folder */
+
 static void
-xviewer_list_store_append_directory (XviewerListStore *store,
+xviewer_list_store_set_directory_callbacks  (XviewerListStore *store,
 				 GFile *file,
 				 GFileType file_type)
 {
 	GFileMonitor *file_monitor;
-	GFileEnumerator *file_enumerator;
-	GFileInfo *file_info;
 
 	g_return_if_fail (file_type == G_FILE_TYPE_DIRECTORY);
 
@@ -500,13 +500,28 @@ xviewer_list_store_append_directory (XviewerListStore *store,
 						 0, NULL, NULL);
 
 	if (file_monitor != NULL) {
-		g_signal_connect (file_monitor, "changed",
-				  G_CALLBACK (file_monitor_changed_cb), store);
+        if (g_list_find(store->priv->monitors, file_monitor) == NULL) {
+		    g_signal_connect (file_monitor, "changed",
+				     G_CALLBACK (file_monitor_changed_cb), store);
 
-		/* prepend seems more efficient to me, we don't need this list
-		   to be sorted */
-		store->priv->monitors = g_list_prepend (store->priv->monitors, file_monitor);
+		    /* prepend seems more efficient to me, we don't need this list
+		        to be sorted */
+		    store->priv->monitors = g_list_prepend (store->priv->monitors, file_monitor);
+        }
 	}
+}
+
+static void
+xviewer_list_store_append_directory (XviewerListStore *store,
+				 GFile *file,
+				 GFileType file_type)
+{
+	GFileEnumerator *file_enumerator;
+	GFileInfo *file_info;
+
+	g_return_if_fail (file_type == G_FILE_TYPE_DIRECTORY);
+
+    xviewer_list_store_set_directory_callbacks (store, file, file_type);
 
 	file_enumerator = g_file_enumerate_children (file,
 						     G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE ","
@@ -550,7 +565,9 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
 	GtkTreeIter iter;
 	gint sort_id = GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID;
 	gboolean singleton_list = FALSE;
-
+    GList *directory_list = NULL;
+    GList *dir_iter;
+ 
 	if (file_list == NULL) {
 		return;
 	}
@@ -627,8 +644,54 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
 			g_object_unref (file);
 		} else if (file_type == G_FILE_TYPE_REGULAR && !singleton_list) {
 			xviewer_list_store_append_image_from_file (store, file);
+
+			file = g_file_get_parent (file);
+			file_info = g_file_query_info (file,
+						       G_FILE_ATTRIBUTE_STANDARD_TYPE,
+						       0, NULL, NULL);
+
+			/* If we can't get a file_info,
+			   file_type will stay as G_FILE_TYPE_REGULAR */
+			if (file_info != NULL) {
+				file_type = g_file_info_get_file_type (file_info);
+				g_object_unref (file_info);
+			}
+                                                        /* attempt to set callbacks for the directories
+                                                           that contain the selected files - otherwise
+                                                           changes by external programs to an image that
+                                                           is currently being displayed will not cause
+                                                           the display to be updated */
+			if (file_type == G_FILE_TYPE_DIRECTORY) {
+                gboolean name_not_found = TRUE;
+
+                gchar * directory_name = g_file_get_basename(file);
+
+                dir_iter = directory_list;
+
+                while ((dir_iter != NULL) && name_not_found) {
+                    if (strcmp(dir_iter->data, directory_name) == 0)
+                        name_not_found = FALSE;
+                    dir_iter = dir_iter->next;
+                }
+
+                if (name_not_found) {
+                    directory_list = g_list_prepend(directory_list, g_strdup(directory_name));
+                    xviewer_list_store_set_directory_callbacks (store, file, file_type);
+                }
+
+                g_free(directory_name);
+           }
 		}
 	}
+
+    if (directory_list != NULL) {
+        dir_iter = directory_list;
+        while (dir_iter != NULL) {
+            g_free(dir_iter->data);
+            dir_iter = dir_iter->next;
+        }
+        g_list_free(directory_list);
+    }
 
 	if (initial_file &&
 	    is_file_in_list_store_file (store, initial_file, &iter)) {


### PR DESCRIPTION
This PR addresses issue #151 

It would appear to be intention that xviewer when the file that is currently being displayed is changed by an external program the display should update to reflect the changes. The update should happen without prompting the user unless the image has been altered within xviewer (for example flipped horizontally).

This display is updated automatically (with or without prompting as noted above) in the following situations:

In nemo right-click on the directory that contains the image and select "Open With/Other Application.../Image Viewer". In this case all of the images in that folder will "in-view" update if they are changed externally.

In nemo right-click on an image file and select "Open With/Other Application.../Image Viewer"

In a terminal window opened in the directory that includes an image type xviewer followed by a single image file name.

The display is NOT updated automatically in the following situations:

In nemo right-click on an image file and select "Open With Image Viewer"  (i.e. not following the Open With route which does work)

In nemo double-click on an image or left-click once and then press Enter

In a terminal window opened in the containing directory type xviewer followed by two or more file names.

Note that what is probably the most common route of opening an image in xviewer (double-clicking the file in nemo) will mean that the external changes are not reflected in the current display.

The reason for the above behaviour is that function xviewer_list_store_add_files() only enables a monitor on the directory that includes the image(s) if it is activated with one (or more) directory names or it is activated with a single image file name. 

Unfortunately double-clicking an an image file in nemo activates xviewer with the names of all of the files that are in the containing directory.

The change to the code is to enable a change monitor for each of the parent directories of the multiple image files (only one monitor for each directory regardless of the number of specified files are within that directory)
