### PR TITLE
Change to shortcut key help

### DIFF
--- a/help/C/shortcuts.page
+++ b/help/C/shortcuts.page
@@ -97,12 +97,12 @@ name</p></td>
          <td><p><key>F</key></p></td>
     </tr>
     <tr>
-    	<td><p>Scroll around a large image</p></td>
-         <td><p><keyseq><key>Alt</key><key>arrow keys</key></keyseq></p></td>
-    </tr>
-    <tr>
     	<td><p>Toggle between 1:1 and best fit</p></td>
          <td><p><key>1</key></p></td>
+    </tr>
+    <tr>
+    	<td><p>Scroll around a large image</p></td>
+         <td><p><keyseq><key>Alt</key><key>arrow keys</key></keyseq></p></td>
     </tr>
     <tr>
     	<td><p>Reload image</p></td>


### PR DESCRIPTION
This is a trivial change to swap the order of two of the keys listed in the "Viewing images" section of the shortcut key help.

The lines  "Toggle between 1:1 and best fit" (key 1) has been swapped with "Scroll around a large image"

This means that "Toggle between 1:1 and best fit" now appears immediately below "Actual size (1:1)" and "Best fit" so that the three related keys are grouped together (a change suggested by the poster of issue #150)
