### PR TITLE
fix: move .typelib and .gir dirs into private dir

### DIFF
--- a/debian/gir1.2-xviewer-3.0.install
+++ b/debian/gir1.2-xviewer-3.0.install
@@ -1,1 +1,1 @@
-usr/lib/*/girepository-1.0/*.typelib
+usr/lib/*/xviewer/girepository-1.0/

--- a/debian/xviewer-dev.install
+++ b/debian/xviewer-dev.install
@@ -1,4 +1,4 @@
 usr/include
 usr/lib/*/pkgconfig
-usr/share/gir-1.0
+usr/share/xviewer/gir-1.0/
 usr/share/gtk-doc

--- a/debian/xviewer.install
+++ b/debian/xviewer.install
@@ -6,4 +6,5 @@ usr/share/help
 usr/share/icons
 usr/share/locale
 usr/share/metainfo/xviewer.appdata.xml
-usr/share/xviewer
+usr/share/xviewer/icons/
+usr/share/xviewer/pixmaps/

--- a/src/meson.build
+++ b/src/meson.build
@@ -193,6 +193,8 @@ gnome.generate_gir(
     identifier_prefix: 'Xviewer',
     symbol_prefix: meson.project_name(),
     install: true,
+    install_dir_gir: xviewer_pkgdatadir / 'gir-1.0',
+    install_dir_typelib: xviewer_pkglibdir / 'girepository-1.0',
 )
 
 pkgconfig.generate(

--- a/src/xviewer-plugin-engine.c
+++ b/src/xviewer-plugin-engine.c
@@ -81,6 +81,7 @@ xviewer_plugin_engine_new (void)
 {
 	XviewerPluginEngine *engine;
 	gchar *user_plugin_path;
+	gchar *typelib_path;
 	const gchar * const * system_data_dirs;
 	GError *error = NULL;
 
@@ -102,9 +103,10 @@ xviewer_plugin_engine_new (void)
 		g_clear_error (&error);
 	}
 
+	typelib_path = g_build_filename (LIBDIR, "xviewer", "girepository-1.0", NULL);
 
-	if (g_irepository_require (g_irepository_get_default (),
-				   "Xviewer", "3.0", 0, &error) == NULL)
+	if (g_irepository_require_private (g_irepository_get_default (), typelib_path,
+					   "Xviewer", "3.0", 0, &error) == NULL)
 	{
 		g_warning ("Error loading Xviewer typelib: %s\n",
 			   error->message);


### PR DESCRIPTION
Currently the file `Xviewer-3.0.typelib` is located in `$libdir/girepository-1.0`,
i.e. `/usr/lib/x86_64-linux-gnu/girepository-1.0/`.

Therefore, it only works as long as the install $prefix is `/usr` but fails for e.g. `/usr/local`
with `Error loading Xviewer typelib: Typelib file for namespace 'Xviewer', version '3.0' not found`
as this path is not in the default g_ir search path.

This commit changes the path to the xviewer pkglibdir, e.g. `/usr/local/lib/x86_64-linux-gnu/xviewer/girepository-1.0/`
and changes the code to load it from there.
This behavior is similar to Xed's.

Also, the path of the .gir file is moved into the private data dir for consistency.