### PR TITLE
Handle repeated prev and next keys (fixes issue 160)

### DIFF
--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -5865,8 +5865,14 @@ xviewer_window_key_press (GtkWidget *widget, GdkEventKey *event)
 					/* If the iconview is not visible skip to the
 					 * previous image manually as it won't handle
 					 * the keypress then. */
-					xviewer_window_cmd_go_prev (NULL,
-								XVIEWER_WINDOW (widget));
+                    if ((previous_key != event->keyval)                     ||
+                        (event->time - last_key_time >= IMAGE_CHANGE_DELAY) ||
+                        (event->time < last_key_time)) {            /* allow for roll-over */
+					    xviewer_window_cmd_go_prev (NULL,
+								    XVIEWER_WINDOW (widget));
+                        last_key_time = event->time;
+                    }
+
 					result = TRUE;
 				} else
 					handle_selection = TRUE;
@@ -5880,8 +5886,13 @@ xviewer_window_key_press (GtkWidget *widget, GdkEventKey *event)
 					/* If the iconview is not visible skip to the
 					 * next image manually as it won't handle
 					 * the keypress then. */
-					xviewer_window_cmd_go_next (NULL,
-								XVIEWER_WINDOW (widget));
+                    if ((previous_key != event->keyval)                     ||
+                        (event->time - last_key_time >= IMAGE_CHANGE_DELAY) ||
+                        (event->time < last_key_time)) {            /* allow for roll-over */
+					    xviewer_window_cmd_go_next (NULL,
+								    XVIEWER_WINDOW (widget));
+                        last_key_time = event->time;
+                    }
 					result = TRUE;
 				} else
 					handle_selection = TRUE;


### PR DESCRIPTION
The current release version (3.2.4) doesn't handle moving to the next or previous images by holding down the appropriate keys - the display just freezes until the key is released.

This pull request sinks any repeated key press events for the next and prev keys until at least 250 milliseconds have passed or the key has been released. This moves from image to image at a rate that allows the user to search for a particular image.

In order to allow rapid press/release cycles of the next and prev keys to work (as they do in the current master version) it was necessary to handle key release events. The existing key press event handler is now called when there is a release event. It handles release events by setting an invalid code into the record of the last key pressed, so that a next/prev key will be processed, and then returns.