### PR TITLE
build: add missing gio-unix-2.0 dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ i18n = import('i18n')
 pkgconfig = import('pkgconfig')
 
 # dependencies
+gio_unix = dependency('gio-unix-2.0', version: '>= 2.38.0')
 glib = dependency('glib-2.0', version: '>= 2.38.0')
 gtk = dependency('gtk+-3.0')
 libpeas = dependency('libpeas-1.0', version: '>= 0.7.4')

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,6 +131,7 @@ xviewer_resources = gnome.compile_resources(
 
 xviewer_deps = [
     config_h,
+    gio_unix,
     glib,
     gtk,
     libpeas,


### PR DESCRIPTION
The Nix package manager used by NixOS (and available on all unix systems), uses a sandboxed environment where it is not possible to have global building dependencies. Without this change the build with fails with:

```
[65/229] Compiling C object src/libxviewer.so.p/xviewer-window.c.o
FAILED: src/libxviewer.so.p/xviewer-window.c.o 
gcc -Isrc/libxviewer.so.p -Isrc -I../src -Ijpegutils -I../jpegutils -I. -I.. -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/0080c7qj9vgmgnq4l0s35n22h3iwv32k-gobject-introspection-1.72.0-dev/include/gobject-introspection-1.0 -I/nix/store/8zjff4d0y6qizr4bxq9rvpbi79b8m444-libpeas-1.32.0-dev/include/libpeas-1.0 -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/df6f01vhldmjmizasn157ah40khnzy6z-zlib-1.2.12-dev/include -I/nix/store/fv80fbb38zy7p2x1xbhsmqakfiyjqkjh-cinnamon-desktop-5.4.1-dev/include/cinnamon-desktop -I/nix/store/250jx90qsk319x97a4af0jglh9qdv2w4-xapps-2.2.13-dev/include/xapp -I/nix/store/jdvysi7p5rkr04cg57cg2knyvlwdz2c0-libexif-0.6.24/include -I/nix/store/1c28xs1yjq4jqcvzdk1wjr0p975r45x1-exempi-2.5.1/include/exempi-2.0 -I/nix/store/1c28xs1yjq4jqcvzdk1wjr0p975r45x1-exempi-2.5.1/include -I/nix/store/rlidd9d6hk2wadpdi9yck9ww136cdh7k-lcms2-2.13.1-dev/include -I/nix/store/94cinbmad5b3f2nqj83wj9i08s3bxk14-librsvg-2.54.4-dev/include/librsvg-2.0 -I/nix/store/9hcpqskzky6gyf3sykmxl3phfxwnx0aq-libjpeg-turbo-2.1.3-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -DHAVE_CONFIG_H -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -fPIC -pthread -MD -MQ src/libxviewer.so.p/xviewer-window.c.o -MF src/libxviewer.so.p/xviewer-window.c.o.d -o src/libxviewer.so.p/xviewer-window.c.o -c ../src/xviewer-window.c
../src/xviewer-window.c:67:10: fatal error: gio/gdesktopappinfo.h: No such file or directory
   67 | #include <gio/gdesktopappinfo.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

See also 

- https://github.com/NixOS/nixpkgs/issues/36468

Thanks for reviewing this :-)