### PR TITLE
Fix potential infinite while loop and interpreting unsigned int as signed.

### DIFF
--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -2513,9 +2513,10 @@ private_timeout (gpointer data)
 	if (xviewer_image_is_animation (img) &&
 	    !g_source_is_destroyed (g_main_current_source ()) &&
 	    priv->is_playing) {
-		while (xviewer_image_iter_advance (img) != TRUE) {}; /* cpu-sucking ? */
+		if (xviewer_image_iter_advance (img) && gdk_pixbuf_animation_iter_get_delay_time (priv->anim_iter) != -1) {
 			g_timeout_add (gdk_pixbuf_animation_iter_get_delay_time (priv->anim_iter), private_timeout, img);
 	 		return FALSE;
+		}
  	}
 	priv->is_playing = FALSE;
 	return FALSE; /* stop playing */


### PR DESCRIPTION
This is a port of a patch for the same bug in EOG.

`xviewer_image_iter_advance` can return false when the animation has looped a set number of times and should stop playing. Currently, if this function returns false, xviewer will get stuck in an infinite loop.
This also fixes interpreting the return value of `gdk_pixbuf_animation_iter_get_delay_time` as if it were an unsigned integer. According to the [documentation](https://docs.gtk.org/gdk-pixbuf/method.PixbufAnimationIter.get_delay_time.html), it returns -1 when the animation should stop playing, which right now just triggers a very very long timeout.

This is a very simple, single-line fix, so it shouldn't be too much work to review.