### PR TITLE
Handle the case if XVIEWER_DATA_DIR "/pixmaps/thumbnail-frame.png" was not found

### DIFF
--- a/src/xviewer-thumbnail.c
+++ b/src/xviewer-thumbnail.c
@@ -404,11 +404,17 @@ xviewer_thumbnail_add_frame (GdkPixbuf *thumbnail)
 	dest_width  = source_width  + 9;
 	dest_height = source_height + 9;
 
-	result_pixbuf = xviewer_thumbnail_stretch_frame_image (frame,
-							   3, 3, 6, 6,
-	                                	           dest_width,
-							   dest_height,
-							   FALSE);
+	// make sure a frame was found
+	if (frame) {
+		result_pixbuf = xviewer_thumbnail_stretch_frame_image (frame,
+								3, 3, 6, 6,
+								dest_width,
+								dest_height,
+								FALSE);
+	} else {
+		// frame was not found -> continue without a frame
+		result_pixbuf = gdk_pixbuf_new (GDK_COLORSPACE_RGB, TRUE, 8, dest_width, dest_height);
+	}
 
 	gdk_pixbuf_copy_area (thumbnail,
 			      0, 0,
@@ -545,5 +551,9 @@ xviewer_thumbnail_init (void)
 
 	if (frame == NULL) {
 		frame = gdk_pixbuf_new_from_file (XVIEWER_DATA_DIR "/pixmaps/thumbnail-frame.png", NULL);
+
+		if(!frame) {
+			g_critical (XVIEWER_DATA_DIR "/pixmaps/thumbnail-frame.png" " was not found");
+		}
 	}
 }


### PR DESCRIPTION
I just compiled xviewer from source and tested it locally using these commands:
```bash
meson setup build
meson compile -C build
./build/src/xviewer
```

I had a problem, that if i give it a list of images as arguments, i could see the initial image and i could go to the next by using the arrows. It updated the title and the status bar, but i would still see the old image in the main view. The stderr would be spammed with this log:
```
(xviewer:119894): GdkPixbuf-CRITICAL **: 18:47:30.108: gdk_pixbuf_copy_area: assertion 'src_pixbuf != NULL' failed
```

Turns out, if you build and run from source, it would use the `/usr/local` prefix (which is fine of cause). But because i never installed it, the file `/usr/local/share/xviewer/pixmaps/thumbnail-frame.png` would not exist. This threw of some internal calculations, making `draw_frame_row` a near endless loop (the integers would underflow at some point).
This is why i added these two small checks to avoid this edge case. In case the frame is not found, xviewer just renders the thumbnail without a frame.

Of cause in a well setup system this should never happen, but i believe it is good practice to protect software even against very rare edge cases. Especially as this protection has basicly no overhead (just 2 null checks).