### PR TITLE
fix xviewer-metadata-sidebar.h include guard typo

### DIFF
--- a/src/xviewer-metadata-sidebar.h
+++ b/src/xviewer-metadata-sidebar.h
@@ -22,7 +22,7 @@
  */
 
 #ifndef __XVIEWER_METADATA_SIDEBAR_H__
-#define __XVIEWER_METADATA_SIDEBAR_H_
+#define __XVIEWER_METADATA_SIDEBAR_H__
 
 #include <glib-object.h>
 #include <gtk/gtk.h>


### PR DESCRIPTION
found by compiling locally with very recent GCC which has a warning for this

```
../src/xviewer-metadata-sidebar.h:24: warning: header guard ‘__XVIEWER_METADATA_SIDEBAR_H__’ followed by ‘#define’ of a different macro [-Wheader-guard]
   24 | #ifndef __XVIEWER_METADATA_SIDEBAR_H__
```