### PR TITLE
fix indent of some new priv->modified code

### DIFF
--- a/src/xviewer-image-jpeg.c
+++ b/src/xviewer-image-jpeg.c
@@ -539,14 +539,14 @@ xviewer_image_jpeg_save_file (XviewerImage *image, const char *file,
 	XviewerJpegSaveMethod method = XVIEWER_SAVE_NONE;
 	gboolean source_is_jpeg = FALSE;
 	gboolean target_is_jpeg = FALSE;
-    gboolean result;
+	gboolean result;
 
 	g_return_val_if_fail (source != NULL, FALSE);
 
 	source_is_jpeg = !g_ascii_strcasecmp (source->format, XVIEWER_FILE_FORMAT_JPEG);
 
-    if (image->priv->modified)
-        xviewer_image_jpeg_update_exif_data (image);       /* delay updating the EXIF data to here otherwise any changes
+	if (image->priv->modified)
+		xviewer_image_jpeg_update_exif_data (image);       /* delay updating the EXIF data to here otherwise any changes
                                                               are lost if the user moves to anther image */
 
 	/* determine which method should be used for saving */

--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -833,12 +833,9 @@ xviewer_image_set_orientation (XviewerImage *img)
 		ExifEntry *entry = exif_data_get_entry (exif,
 							EXIF_TAG_ORIENTATION);
 
-        if (priv->modified)
-        {
-            priv->orientation = 1;
-        }
-        else
-		if (entry && entry->data != NULL) {
+		if (priv->modified) {
+			priv->orientation = 1;
+		} else if (entry && entry->data != NULL) {
 			priv->orientation = exif_get_short (entry->data, o);
 		}
 
@@ -1269,8 +1266,8 @@ xviewer_image_real_load (XviewerImage *img,
 				 * images as well. */
 				g_clear_error (error);
 			}
-	        }
-        }
+		}
+	}
 
 	g_free (buffer);
 


### PR DESCRIPTION
Some new code related to priv-modified was added with 4-space indent instead of tab indent, and it triggered warnings in recent GCC for misleading indents. Fix to tab indents (and surrounding brace style).

```
../src/xviewer-image-jpeg.c:548:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  548 |     if (image->priv->modified)
      |     ^~
../src/xviewer-image-jpeg.c:553:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  553 |         if (target == NULL) {
      |         ^~
```

```
../src/xviewer-image.c:840:9: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
  840 |         else
      |         ^~~~
../src/xviewer-image.c:845:17: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
  845 |                 exif_data_unref (exif);
      |                 ^~~~~~~~~~~~~~~
```