### PR TITLE
Fix GDK-PixBuf refcounting

### DIFF
--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -1301,6 +1301,7 @@ xviewer_image_real_load (XviewerImage *img,
 		{
 
 		priv->anim = gdk_pixbuf_loader_get_animation (loader);
+		g_object_ref (priv->anim);
 
 		if (gdk_pixbuf_animation_is_static_image (priv->anim)) {
 			priv->image = gdk_pixbuf_animation_get_static_image (priv->anim);


### PR DESCRIPTION
`gdk_pixbuf_loader_get_animation` doesn't return a new reference.

Closes: https://github.com/linuxmint/xviewer/issues/220