### PR TITLE
Fix a focus bug when opening a new maximized window

### DIFF
--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -6235,6 +6235,7 @@ xviewer_window_new (XviewerStartupFlags flags)
 					   "startup-flags", flags,
 					   NULL));
 
+	gtk_window_set_focus_on_map (GTK_WINDOW (window), TRUE);
 	return GTK_WIDGET (window);
 }
 


### PR DESCRIPTION
This fixes a bug that causes a new maximized window to not be focussed in Cinnamon on X11.