### PR TITLE
Usability improvement - persist phantom images in the list-store

### DIFF
--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -647,10 +647,13 @@ xviewer_image_get_file_info (XviewerImage *img,
 		if (mime_type)
 			*mime_type = NULL;
 
-		g_set_error (error,
-			     XVIEWER_IMAGE_ERROR,
-			     XVIEWER_IMAGE_ERROR_VFS,
-			     "Error in getting image file info");
+		if (error && *error == NULL)
+		{
+			g_set_error (error,
+					XVIEWER_IMAGE_ERROR,
+					XVIEWER_IMAGE_ERROR_VFS,
+					"Error in getting image file info");
+		}
 	} else {
 		if (bytes)
 			*bytes = g_file_info_get_size (file_info);

--- a/src/xviewer-list-store.c
+++ b/src/xviewer-list-store.c
@@ -375,84 +375,37 @@ file_monitor_changed_cb (GFileMonitor *monitor,
 			 GFileMonitorEvent event,
 			 XviewerListStore *store)
 {
-	const char *mimetype;
-	GFileInfo *file_info;
-	GtkTreeIter iter;
-	XviewerImage *image;
+	if (event == G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT)
+	{
+		const char *mimetype;
+		GFileInfo *file_info;
+		GtkTreeIter iter;
+		XviewerImage *image;
 
-	switch (event) {
-	case G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT:
 		file_info = g_file_query_info (file,
 					       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE,
 					       0, NULL, NULL);
 		if (file_info == NULL) {
-			break;
+			return;
 		}
 		mimetype = g_file_info_get_content_type (file_info);
-
-		if (is_file_in_list_store_file (store, file, &iter)) {
-			if (xviewer_image_is_supported_mime_type (mimetype)) {
+		if (xviewer_image_is_supported_mime_type (mimetype)) {
+			gboolean found = is_file_in_list_store_file (store, file, &iter);
+			if (found) {
 				gtk_tree_model_get (GTK_TREE_MODEL (store), &iter,
-						    XVIEWER_LIST_STORE_XVIEWER_IMAGE, &image,
-						    -1);
+							XVIEWER_LIST_STORE_XVIEWER_IMAGE, &image,
+							-1);
 				xviewer_image_file_changed (image);
 				g_object_unref (image);
-				xviewer_list_store_thumbnail_refresh (store, &iter);
 			} else {
-				xviewer_list_store_remove (store, &iter);
-			}
-		} else {
-			if (xviewer_image_is_supported_mime_type (mimetype)) {
 				xviewer_list_store_append_image_from_file (store, file);
+				found = is_file_in_list_store_file (store, file, &iter);
 			}
+			
+			if (found)
+				xviewer_list_store_thumbnail_refresh (store, &iter);
 		}
 		g_object_unref (file_info);
-		break;
-	case G_FILE_MONITOR_EVENT_DELETED:
-		if (is_file_in_list_store_file (store, file, &iter)) {
-			XviewerImage *image;
-
-			gtk_tree_model_get (GTK_TREE_MODEL (store), &iter,
-					    XVIEWER_LIST_STORE_XVIEWER_IMAGE, &image,
-					    -1);
-
-			xviewer_list_store_remove (store, &iter);
-		}
-		break;
-	case G_FILE_MONITOR_EVENT_CREATED:
-		if (!is_file_in_list_store_file (store, file, NULL)) {
-			file_info = g_file_query_info (file,
-						       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE,
-						       0, NULL, NULL);
-			if (file_info == NULL) {
-				break;
-			}
-			mimetype = g_file_info_get_content_type (file_info);
-
-			if (xviewer_image_is_supported_mime_type (mimetype)) {
-				xviewer_list_store_append_image_from_file (store, file);
-			}
-			g_object_unref (file_info);
-		}
-		break;
-	case G_FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED:
-		file_info = g_file_query_info (file,
-					       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE,
-					       0, NULL, NULL);
-		if (file_info == NULL) {
-			break;
-		}
-		mimetype = g_file_info_get_content_type (file_info);
-		if (is_file_in_list_store_file (store, file, &iter) &&
-		    xviewer_image_is_supported_mime_type (mimetype)) {
-			xviewer_list_store_thumbnail_refresh (store, &iter);
-		}
-		g_object_unref (file_info);
-		break;
-	case G_FILE_MONITOR_EVENT_PRE_UNMOUNT:
-	case G_FILE_MONITOR_EVENT_UNMOUNTED:
-	case G_FILE_MONITOR_EVENT_MOVED:
-		break;
 	}
 }
 

--- a/src/xviewer-thumbnail.c
+++ b/src/xviewer-thumbnail.c
@@ -192,14 +192,13 @@ xviewer_thumb_data_new (GFile *file, GError **error)
 			data->can_read = g_file_info_get_attribute_boolean (file_info,
 									    G_FILE_ATTRIBUTE_ACCESS_CAN_READ);
 		}
+		g_object_unref (file_info);
 	}
 	else {
 		xviewer_thumb_data_free (data);
 		data = NULL;
 		g_clear_error (&ioerror);
 	}
-
-	g_object_unref (file_info);
 
 	return data;
 }

--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -556,9 +556,9 @@ update_status_bar (XviewerWindow *window)
 
 			g_free (size_string);
 		}
-
-		update_image_pos (window);
 	}
+
+	update_image_pos (window);
 
 	gtk_statusbar_pop (GTK_STATUSBAR (priv->statusbar),
 			   priv->image_info_message_cid);


### PR DESCRIPTION
A common workflow for me is opening a directory of unsorted photos with xviewer, scrolling through them and using drag and drop back to nemo to move them into other directories.
In the current behaviour, the image remains open after being moved but when I try go to the next image, it restarts me from the beginning of the list (frustrating).

The current behaviour appears to strike a hacky balance between actively reflecting "external" file/directory changes and not vanishing an open image immediately when it's externally moved or deleted (https://github.com/linuxmint/xviewer/issues/184). The image remains open but is removed from the list-store, hence the position loss when scrolling.

Here I propose a cleaner solution: A persistent gallery. The image stays open and retains its position in the list-store, allowing the user to scroll on intuitively. If they return to the moved image, it fails to reload from the disk. I believe this provides a more intuitive experience and better facilitates moving and renaming while organising images from from inside the application and externally.

PR also includes some small misc fixes.