### PR TITLE
Update state after opening images

### DIFF
--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -1414,6 +1414,7 @@ xviewer_job_load_cb (XviewerJobLoad *job, gpointer data)
 		}
 
 		xviewer_window_display_image (window, job->image);
+		update_action_groups_state (window);
 
 	} else {
 		GtkWidget *message_area;


### PR DESCRIPTION
This fixes the problem that the images won't be shown if the application was launched without initially specifying an image file.