### PR TITLE
Update control: Added libjpeg-dev to xviwer-dev depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,7 @@ Section: libdevel
 Architecture: any
 Depends: gir1.2-xviewer-3.0 (= ${binary:Version}),
          libgtk-3-dev,
+         libjpeg-dev,
          xviewer (>= ${binary:Version}),
          ${misc:Depends}
 Description: Development files for Xviewer


### PR DESCRIPTION
 Added libjpeg-dev to xviwer-dev depends

Required for xviewer-plugin build.

"Called: `/usr/bin/pkg-config --cflags xviewer` -> 1 stderr:
Package libjpeg was not found in the pkg-config search path. Perhaps you should add the directory containing `libjpeg.pc' to the PKG_CONFIG_PATH environment variable
Package 'libjpeg', required by 'xviewer', not found"