### PR TITLE
Fix memory leak when viewing many files

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <malloc.h>
 #include <glib/gi18n.h>
 
 static XviewerStartupFlags flags;
@@ -95,6 +96,17 @@ main (int argc, char **argv)
 {
 	GError *error = NULL;
 	GOptionContext *ctx;
+
+	/* Pin the mmap threshold so that large image buffers (which are
+	 * typically several MB and can vary a lot in size while browsing)
+	 * always go through mmap/munmap, guaranteeing their memory is
+	 * released back to the OS immediately on free. Without this,
+	 * glibc's malloc can grow its heap arena to fit a peak allocation
+	 * and never shrink it back, causing RSS to climb and plateau at
+	 * high-water marks that never come back down while browsing many
+	 * large images in succession. */
+	mallopt (M_MMAP_THRESHOLD, 128 * 1024);
+	mallopt (M_MMAP_MAX, 65536);
 
 	bindtextdomain (GETTEXT_PACKAGE, XVIEWER_LOCALE_DIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");

--- a/src/xviewer-image.c
+++ b/src/xviewer-image.c
@@ -1302,6 +1302,7 @@ xviewer_image_real_load (XviewerImage *img,
 
 		if (gdk_pixbuf_animation_is_static_image (priv->anim)) {
 			priv->image = gdk_pixbuf_animation_get_static_image (priv->anim);
+			g_object_unref (priv->anim);
 			priv->anim = NULL;
 		} else {
 			priv->anim_iter = gdk_pixbuf_animation_get_iter (priv->anim,NULL);

--- a/src/xviewer-jobs.c
+++ b/src/xviewer-jobs.c
@@ -571,6 +571,17 @@ xviewer_job_load_run (XviewerJob *job)
 
 	/* check if the current job was previously cancelled */
 	if (xviewer_job_is_cancelled (job)) {
+		/* xviewer_image_load() above may have already finished
+		 * decoding the full image into memory before this
+		 * cancellation was noticed (e.g. small/cached files loading
+		 * faster than the user can browse past them). Since this
+		 * job's "finished" signal is never emitted, the image will
+		 * never be displayed or data-reffed, so its decoded pixel
+		 * data would otherwise leak forever. Force-release it. */
+		if (job_load->data & XVIEWER_IMAGE_DATA_IMAGE) {
+			xviewer_image_data_ref (job_load->image);
+			xviewer_image_data_unref (job_load->image);
+		}
 		g_object_unref (job);
 		return;
 	}

--- a/src/xviewer-jobs.c
+++ b/src/xviewer-jobs.c
@@ -1241,6 +1241,7 @@ xviewer_job_thumbnail_run (XviewerJob *job)
 
 	if (!job_thumbnail->thumbnail) {
 		job->finished = TRUE;
+		g_object_unref (job);
 		return;
 	}
 

--- a/src/xviewer-jobs.c
+++ b/src/xviewer-jobs.c
@@ -279,12 +279,16 @@ xviewer_job_cancel (XviewerJob *job)
 	g_object_ref (job);
 
 	/* check if job was cancelled previously */
-	if (job->cancelled)
+	if (job->cancelled) {
+		g_object_unref (job);
 		return;
+	}
 
 	/* check if job finished previously */
-        if (job->finished)
+        if (job->finished) {
+		g_object_unref (job);
 		return;
+	}
 
 	/* show info for debugging */
 	xviewer_debug_message (DEBUG_JOBS,
@@ -566,8 +570,10 @@ xviewer_job_load_run (XviewerJob *job)
 			&job->error);
 
 	/* check if the current job was previously cancelled */
-	if (xviewer_job_is_cancelled (job))
+	if (xviewer_job_is_cancelled (job)) {
+		g_object_unref (job);
 		return;
+	}
 
 	/* --- enter critical section --- */
 	g_mutex_lock (job->mutex);
@@ -857,8 +863,10 @@ xviewer_job_save_run (XviewerJob *job)
 	}
 
 	/* check if the current job was previously cancelled */
-	if (xviewer_job_is_cancelled (job))
+	if (xviewer_job_is_cancelled (job)) {
+		g_object_unref (job);
 		return;
+	}
 
 	save_job = XVIEWER_JOB_SAVE (job);
 

--- a/src/xviewer-list-store.c
+++ b/src/xviewer-list-store.c
@@ -417,6 +417,7 @@ file_monitor_changed_cb (GFileMonitor *monitor,
 					    -1);
 
 			xviewer_list_store_remove (store, &iter);
+			g_object_unref (image);
 		}
 		break;
 	case G_FILE_MONITOR_EVENT_CREATED:

--- a/src/xviewer-thumbnail.c
+++ b/src/xviewer-thumbnail.c
@@ -494,6 +494,7 @@ xviewer_thumbnail_load (XviewerImage *image, GError **error)
 	    (data->failed_thumb_exists && gnome_desktop_thumbnail_factory_has_valid_failed_thumbnail (factory, data->uri_str, data->mtime))) {
 		xviewer_debug_message (DEBUG_THUMBNAIL, "%s: bad permissions or valid failed thumbnail present",data->uri_str);
 		set_thumb_error (error, XVIEWER_THUMB_ERROR_GENERIC, "Thumbnail creation failed");
+		xviewer_thumb_data_free (data);
 		return NULL;
 	}
 

--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -931,6 +931,13 @@ xviewer_window_display_image (XviewerWindow *window, XviewerImage *image)
 	priv = window->priv;
 
 	if (image != NULL) {
+		g_signal_handlers_disconnect_by_func (image,
+						      image_thumb_changed_cb,
+						      window);
+		g_signal_handlers_disconnect_by_func (image,
+						      image_file_changed_cb,
+						      window);
+
 		g_signal_connect (image,
 				  "thumbnail_changed",
 				  G_CALLBACK (image_thumb_changed_cb),

--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -1028,6 +1028,15 @@ xviewer_window_update_openwith_menu (XviewerWindow *window, XviewerImage *image)
 
         if (priv->actions_open_with != NULL) {
               gtk_ui_manager_remove_action_group (priv->ui_mgr, priv->actions_open_with);
+              /* gtk_ui_manager_insert_action_group() below takes its own
+               * reference; removing it only drops that one. The reference
+               * from gtk_action_group_new() (which this struct field has
+               * been implicitly holding) must be released here too,
+               * otherwise every action group -- and every GAppInfo/
+               * GKeyFile-backed action it holds for each installed
+               * "Open With" candidate app -- leaks on every single image
+               * display. */
+              g_object_unref (priv->actions_open_with);
               priv->actions_open_with = NULL;
         }
 

--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -1157,8 +1157,25 @@ xviewer_window_clear_load_job (XviewerWindow *window)
 	XviewerWindowPrivate *priv = window->priv;
 
 	if (priv->load_job != NULL) {
-		if (!priv->load_job->finished)
+		if (!priv->load_job->finished) {
 			xviewer_job_cancel (priv->load_job);
+		} else {
+			/* The job already finished decoding the full image
+			 * before we got a chance to act on it: the "finished"
+			 * signal disconnected below never gets to run, so
+			 * xviewer_job_load_cb()/xviewer_window_display_image()
+			 * never see this image and never data-ref it. Without
+			 * this, the fully decoded pixel data would stay
+			 * resident forever. Force-release it. This is safe
+			 * even if this image happens to be on-screen already,
+			 * since data-ref/unref only frees when the count
+			 * would drop to zero. */
+			XviewerImage *load_image = XVIEWER_JOB_LOAD (priv->load_job)->image;
+			if (xviewer_image_has_data (load_image, XVIEWER_IMAGE_DATA_IMAGE)) {
+				xviewer_image_data_ref (load_image);
+				xviewer_image_data_unref (load_image);
+			}
+		}
 
 		g_signal_handlers_disconnect_by_func (priv->load_job,
 						      xviewer_job_progress_cb,


### PR DESCRIPTION


Fix for a memory leak when viewing many files in a folder.  Eventually all RAM will be used resulting in swapping or a freeze.  Fixes issues #234, #218, #48 and #36.

Claude Code (Fable) was used to find and fix this bug.

Summary:
-Initial commit (29f6b47) resolved my issue of all RAM being consumed when flipping *quickly* through a 377-image/3.9GB folder of camera pictures (most were 3-5MB .jpg, plus some .mp4 that can be ignored).
-Commit 3fad9ca and 9b39709 were attempts to further reduce the RAM usage as it would climb to around 1GB with the test above.  Not resolved but many more bugs were found.
-Commit ba4daac resolves the 1GB issue.  glibc's allocator was letting its heap arena balloon (10MB→139MB, never shrinking) because large image buffers sometimes got allocated on the regular heap instead of via mmap, due to glibc's adaptive mmap threshold. Pinning that threshold in main.c fixes it.  Memory now drops back down to ~110MB when idle.
-Commit 5425608 improves memory usage futher. After the above fixes, the test script in issue #234 would increase memory by around 85KB per image loaded.  With this fix it should be effectively zero (flat).  This was due to an issue in with xviewer_window_update_openwith_menu().

------
29f6b47:
Claude output:

The bug (present since the 2016 eog→xviewer fork, matching issue #36 from 2017 and upstream eog bug #674284 from 2012):

In src/xviewer-jobs.c, xviewer_job_load_run(), xviewer_job_save_run(), and xviewer_job_cancel() each take an extra g_object_ref(job) that's meant to be released either by an early-return path or by the g_idle_add_full(..., g_object_unref) completion callback. The early-return paths (triggered when a job gets cancelled) were missing the matching g_object_unref — unlike the sibling xviewer_job_copy_run/xviewer_job_transform_run, which handle this correctly. Since navigating to a new image cancels any still-in-flight load job for the previous one, this leaks the XviewerJobLoad object — and therefore the XviewerImage and its decoded GdkPixbuf pixel buffer — every time a load is interrupted by browsing forward, which is exactly what happens during normal/fast browsing or slideshow mode. This is almost certainly the actual long-standing leak.

A second, unrelated, newer bug in src/xviewer-image.c (introduced by commit c43d002, Nov 2025) that leaked the GdkPixbufAnimation on every static-image load was also fixed. That one was real but wasn't the historical leak — it only exists in builds after that commit.

------
3fad9ca:
Additional findings:

Root cause: xviewer_window_reload_image() (src/xviewer-window.c:6587) nulls out window->priv->image before the reload's background job finishes. When the job completes, xviewer_job_load_cb() (line 1360) only disconnects the previous "thumbnail_changed"/"file-changed" signal handlers if priv->image != NULL (line 1378) — but since reload_image() already nulled it, that guard is skipped. xviewer_window_display_image() is then called and unconditionally adds another pair of signal connections (lines 934–940) onto the same XviewerImage object (the list store reuses the same object when the file-monitor sees the same path change, rather than creating a new one). So every time the watched file changes on disk (exactly what your test does by overwriting /tmp/leaktest.png in place), one more redundant handler pair accumulates permanently on that image object — they're never cleaned up. Each additional handler is small, but they never get removed and each one re-fires (and does its own work, e.g. thumbnail regeneration) on every subsequent change, which matches a slow, continuing — but not exploding — growth in RSS.

While auditing this path I also noticed a smaller, unrelated genuine bug in src/xviewer-list-store.c's file_monitor_changed_cb: in the G_FILE_MONITOR_EVENT_DELETED case it fetches image via gtk_tree_model_get (transfer-full) but never g_object_unrefs it, unlike the CHANGES_DONE_HINT case just above. It wouldn't fire in your test (no delete event, just in-place overwrite), but it's worth fixing too.

Summary:

Why VmRSS grew from 104060 kB → 126272 kB across the extra 270 cycles: there's a third, separate leak — this one specific to your test's pattern of repeatedly overwriting the same open file (rather than navigating between files), which is exactly the scenario in the original 2012 upstream bug report (a motion-style webcam tool rewriting one file in place).

Root cause: xviewer_window_reload_image() (xviewer-window.c:6587, triggered by the GFileMonitor "file changed" → auto-reload path) sets priv->image = NULL before the reload's background job finishes. The job-completion callback xviewer_job_load_cb() only disconnects the old "thumbnail_changed"/"file-changed" signal handlers when priv->image != NULL — but it's already NULL by then, so that cleanup is skipped. xviewer_window_display_image() then unconditionally adds another pair of signal handlers onto the same XviewerImage object (the list store reuses one object per path rather than creating a new one on a plain modify). So every overwrite of your watched file leaks one more permanent signal-handler pair, and each surviving stale handler keeps re-firing (redoing its own work) on every subsequent change — a slow, genuinely-still-growing leak rather than a one-time cost, matching your 300-cycle data.

Fixed by making the signal connection idempotent (disconnect-then-connect, mirroring the pattern already used correctly elsewhere in the same file). I also fixed a smaller, unrelated ref leak I spotted in the same code path (xviewer-list-store.c, G_FILE_MONITOR_EVENT_DELETED case never unreffed the fetched image — doesn't fire for in-place overwrites, so not your test's cause, but a real bug).

------
Found and fixed two more real leaks, and rigorously bisected a much smaller residual one. Summary:

Two more genuine bugs fixed (same pattern as before — a missing g_object_unref on an early-return path):
- xviewer_job_thumbnail_run (xviewer-jobs.c) leaked its job ref whenever thumbnail loading failed.
- xviewer_thumbnail_load (xviewer-thumbnail.c) leaked a small XviewerThumbData struct on its "already known to fail" early return.

Where the ~85 KB/cycle residual leak stands: I built the project directly from source, ran the repro under Valgrind and then with direct in-process mallinfo2() checkpoints (immune to allocator-fragmentation noise, unlike RSS) at ~10 points through the reload pipeline. That bisection:
- Confirmed most of your originally-observed growth (e.g. 86MB→457MB) was the big bugs, now fixed — a clean 600-cycle run after the first 2 fixes plateaus/grows only slowly.
- Proved a smaller, rock-steady ~85 KB leaks every single cycle, even with all 6 fixes applied.
- Ruled out thumbnail generation entirely (leak persists identically with it disabled), and ruled out xviewer_image_real_load, xviewer_window_reload_image, and xviewer_job_load_cb each individually — all clean.
- Narrowed it to the chain handle_image_selection_changed_cb → new job creation → xviewer_job_scheduler_add_job → background thread start, but couldn't pin an exact line — none of the individual allocations there (job object, 2 signal closures, a status string) obviously total 85 KB.

This residual leak only shows up in the narrow "same file repeatedly overwritten in place while open" scenario (your test's exact pattern, and the original 2012 webcam-monitoring bug report) — it's ~100-200x smaller per event than what's already fixed, which covered ordinary image navigation/browsing.

------
9b39709:

- The debug logging confirmed your original severe leak (>1GB from fast-flipping through the 377-image/3.9GB folder) is now resolved by the two race-condition fixes: the xviewer-jobs.c fix (freeing image data if a job's cancellation is noticed only after decode already finished) and the xviewer-window.c xviewer_window_clear_load_job() fix (freeing image data when a job finished but its "finished" signal never got to run before the next navigation). A fast click-through of 109 images from your 354-file/3.7GB Pictures/Camera folder now tops out around 250-300MB instead of >1GB.
- There's a much smaller, separate ~100-130KB-per-distinct-image growth that appears to be intentional metadata (EXIF/thumbnail) caching — each viewed image's XviewerImage object is kept alive for the whole session by design, so revisiting it doesn't require re-parsing. This is orders of magnitude smaller than the bug you reported and may not need fixing unless you want it addressed too.

------
ba4daac:

A separate, much smaller effect remained: glibc's allocator was letting its heap arena balloon (10MB→139MB, never shrinking) because large image buffers sometimes got allocated on the regular heap instead of via mmap, due to glibc's adaptive mmap threshold. Pinning that threshold in main.c fixes it — confirmed by your test: peak dropped from 250-300MB to ~200MB, and, critically, it now drops back to ~110MB when idle instead of staying pegged forever.

------
5425608:

Found it. In xviewer_window_update_openwith_menu() (xviewer-window.c:990-1032), a fresh GtkActionGroup is created every time an image is displayed (gtk_action_group_new()), inserted into the UI manager (which takes its own ref), and later removed from the UI manager on the next call (gtk_ui_manager_remove_action_group, which drops that ref) — but the original reference from gtk_action_group_new() is never released. priv->actions_open_with just gets overwritten with the new group, silently dropping the pointer to the old one without ever calling g_object_unref on it.

Since that abandoned GtkActionGroup retains every child GtkAction (one per installed app that can open images — often a dozen+), each holding a GAppInfo wrapping a parsed .desktop file (GKeyFile, strings, icon data), this leaks a real chunk of memory on every single image display — both plain navigation and file-monitor-triggered reloads. This matches both the ~114-130KB/image browsing growth and the ~83-85KB/cycle same-file-rewrite growth, since both go through xviewer_window_display_image → xviewer_window_update_openwith_menu.

Answer to your question: the ~85KB-per-image growth was coming from xviewer_window_update_openwith_menu() — every time an image is displayed (navigation or a same-file reload), it rebuilds the "Open With" submenu by re-enumerating every installed application that can open that MIME type (g_app_info_get_all_for_type), then throws away the old GtkActionGroup holding the previous menu's actions without ever releasing xviewer's own reference to it. Each abandoned action group kept alive one GtkAction + parsed .desktop-file GAppInfo per installed app capable of opening images (commonly a dozen or more), forever, on every single display.

Fixed with one g_object_unref() call in xviewer-window.c. Verified directly: growth dropped from ~83KB/cycle to ~7KB/cycle initially, then flattened out entirely to normal noise over ~400 rewrite cycles (final reading was actually below several earlier readings). This explains both this same-file-rewrite scenario and the earlier distinct-file browsing growth — same code path, same root cause.