### PR TITLE
Defer gallery model population until first image is shown

### DIFF
--- a/src/xviewer-jobs.c
+++ b/src/xviewer-jobs.c
@@ -727,8 +727,10 @@ xviewer_job_model_run (XviewerJob *job)
 	/* --- enter critical section --- */
 	g_mutex_lock (job->mutex);
 
-	/* create a list store */
-	job_model->store = XVIEWER_LIST_STORE (xviewer_list_store_new ());
+	/* create or reuse the list store */
+	if (job_model->store == NULL) {
+		job_model->store = XVIEWER_LIST_STORE (xviewer_list_store_new ());
+	}
 	xviewer_list_store_add_files (job_model->store, filtered_list);
 
 	/* --- leave critical section --- */

--- a/src/xviewer-list-store.c
+++ b/src/xviewer-list-store.c
@@ -355,6 +355,18 @@ xviewer_list_store_append_image (XviewerListStore *store, XviewerImage *image)
 			    -1);
 }
 
+void
+xviewer_list_store_append_file (XviewerListStore *store, GFile *file)
+{
+	XviewerImage *image;
+
+	g_return_if_fail (XVIEWER_IS_LIST_STORE (store));
+	g_return_if_fail (file != NULL);
+
+	image = xviewer_image_new_file (file);
+	xviewer_list_store_append_image (store, image);
+}
+
 static void
 xviewer_list_store_append_image_from_file (XviewerListStore *store,
 				       GFile *file)
@@ -563,8 +575,8 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
 	GFileType file_type;
 	GFile *initial_file = NULL;
 	GtkTreeIter iter;
-	gint sort_id = GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID;
 	gboolean singleton_list = FALSE;
+	gboolean default_sort_after_load = FALSE;
     GList *directory_list = NULL;
     GList *dir_iter;
  
@@ -573,11 +585,11 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
 	}
 	if (file_list->next == NULL) {
 		singleton_list = TRUE;
-		sort_id = GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID;
+		default_sort_after_load = TRUE;
 	}
 
 	gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (store),
-					      sort_id,
+					      GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
 					      GTK_SORT_ASCENDING);
 
 	for (it = file_list; it != NULL; it = it->next) {
@@ -606,13 +618,7 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
 		g_object_unref (file_info);
 
 		if (file_type == G_FILE_TYPE_DIRECTORY) {
-			if (sort_id != GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID) {
-				// Given file order isn't conclusive, re-sort in default order.
-				sort_id = GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID;
-				gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (store),
-					  sort_id,
-					  GTK_SORT_ASCENDING);
-			}
+			default_sort_after_load = TRUE;
 			xviewer_list_store_append_directory (store, file, file_type);
 		} else if (file_type == G_FILE_TYPE_REGULAR && singleton_list) {
 
@@ -685,6 +691,12 @@ xviewer_list_store_add_files (XviewerListStore *store, GList *file_list)
 			    g_object_unref (file);
            }
 		}
+	}
+
+	if (default_sort_after_load) {
+		gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (store),
+					      GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID,
+					      GTK_SORT_ASCENDING);
 	}
 
 	if (directory_list != NULL)

--- a/src/xviewer-list-store.h
+++ b/src/xviewer-list-store.h
@@ -80,6 +80,9 @@ GtkListStore   *xviewer_list_store_new_from_glist 	     (GList *list);
 void            xviewer_list_store_append_image 	     (XviewerListStore *store,
 						      XviewerImage     *image);
 
+void            xviewer_list_store_append_file 	     (XviewerListStore *store,
+						      GFile            *file);
+
 void            xviewer_list_store_add_files 	     (XviewerListStore *store,
 						      GList        *file_list);
 

--- a/src/xviewer-window.c
+++ b/src/xviewer-window.c
@@ -602,6 +602,11 @@ update_action_groups_state (XviewerWindow *window)
 	GtkAction *action_fscreen;
 	GtkAction *action_sshow;
 	GtkAction *action_print;
+	GtkAction *action_prev;
+	GtkAction *action_next;
+	GtkAction *action_first;
+	GtkAction *action_last;
+	GtkAction *action_random;
 	gboolean print_disabled = FALSE;
 	gboolean show_image_gallery = FALSE;
 	gint n_images = 0;
@@ -631,12 +636,32 @@ update_action_groups_state (XviewerWindow *window)
 	action_print =
 		gtk_action_group_get_action (priv->actions_image,
 					     "ImagePrint");
+	action_prev =
+		gtk_action_group_get_action (priv->actions_gallery,
+					     "GoPrevious");
+	action_next =
+		gtk_action_group_get_action (priv->actions_gallery,
+					     "GoNext");
+	action_first =
+		gtk_action_group_get_action (priv->actions_gallery,
+					     "GoFirst");
+	action_last =
+		gtk_action_group_get_action (priv->actions_gallery,
+					     "GoLast");
+	action_random =
+		gtk_action_group_get_action (priv->actions_gallery,
+					     "GoRandom");
 
 	g_assert (action_gallery != NULL);
 	g_assert (action_sidebar != NULL);
 	g_assert (action_fscreen != NULL);
 	g_assert (action_sshow != NULL);
 	g_assert (action_print != NULL);
+	g_assert (action_prev != NULL);
+	g_assert (action_next != NULL);
+	g_assert (action_first != NULL);
+	g_assert (action_last != NULL);
+	g_assert (action_random != NULL);
 
 	if (priv->store != NULL) {
 		n_images = xviewer_list_store_length (XVIEWER_LIST_STORE (priv->store));
@@ -651,6 +676,11 @@ update_action_groups_state (XviewerWindow *window)
 
 		gtk_action_set_sensitive (action_fscreen, FALSE);
 		gtk_action_set_sensitive (action_sshow,   FALSE);
+		gtk_action_set_sensitive (action_prev, FALSE);
+		gtk_action_set_sensitive (action_next, FALSE);
+		gtk_action_set_sensitive (action_first, FALSE);
+		gtk_action_set_sensitive (action_last, FALSE);
+		gtk_action_set_sensitive (action_random, FALSE);
 
 		/* If there are no images on model, initialization
  		   stops here. */
@@ -686,6 +716,11 @@ update_action_groups_state (XviewerWindow *window)
 		gtk_action_group_set_sensitive (priv->actions_image,  TRUE);
 
 		gtk_action_set_sensitive (action_fscreen, TRUE);
+		gtk_action_set_sensitive (action_prev, n_images > 1);
+		gtk_action_set_sensitive (action_next, n_images > 1);
+		gtk_action_set_sensitive (action_first, n_images > 1);
+		gtk_action_set_sensitive (action_last, n_images > 1);
+		gtk_action_set_sensitive (action_random, n_images > 1);
 
 		if (n_images == 1) {
 			gtk_action_group_set_sensitive (priv->actions_gallery,
@@ -6288,12 +6323,9 @@ xviewer_job_model_cb (XviewerJobModel *job, gpointer data)
 	window = XVIEWER_WINDOW (data);
 	priv = window->priv;
 
-	if (priv->store != NULL) {
-		g_object_unref (priv->store);
-		priv->store = NULL;
+	if (priv->store == NULL) {
+		priv->store = g_object_ref (job->store);
 	}
-
-	priv->store = g_object_ref (job->store);
 
 	n_images = xviewer_list_store_length (XVIEWER_LIST_STORE (priv->store));
 
@@ -6306,18 +6338,6 @@ xviewer_job_model_cb (XviewerJobModel *job, gpointer data)
 		}
 	}
 #endif
-
-	xviewer_thumb_view_set_model (XVIEWER_THUMB_VIEW (priv->thumbview), priv->store);
-
-	g_signal_connect (G_OBJECT (priv->store),
-			  "row-inserted",
-			  G_CALLBACK (xviewer_window_list_store_image_added),
-			  window);
-
-	g_signal_connect (G_OBJECT (priv->store),
-			  "row-deleted",
-			  G_CALLBACK (xviewer_window_list_store_image_removed),
-			  window);
 
 	if (n_images == 0) {
 		gint n_files;
@@ -6359,6 +6379,8 @@ void
 xviewer_window_open_file_list (XviewerWindow *window, GSList *file_list)
 {
 	XviewerJob *job;
+	XviewerListStore *store;
+	GFile *initial_file = NULL;
 
 	xviewer_debug (DEBUG_WINDOW);
 
@@ -6367,7 +6389,34 @@ xviewer_window_open_file_list (XviewerWindow *window, GSList *file_list)
 	g_slist_foreach (file_list, (GFunc) g_object_ref, NULL);
 	window->priv->file_list = file_list;
 
+	store = XVIEWER_LIST_STORE (xviewer_list_store_new ());
+	window->priv->store = g_object_ref (store);
+
+	if (file_list != NULL) {
+		initial_file = G_FILE (file_list->data);
+		xviewer_list_store_append_file (store, initial_file);
+	}
+
+	xviewer_thumb_view_set_model (XVIEWER_THUMB_VIEW (window->priv->thumbview), store);
+
+	if (xviewer_list_store_length (store) > 0) {
+		GtkTreePath *path = gtk_tree_path_new_from_indices (0, -1);
+		gtk_icon_view_select_path (GTK_ICON_VIEW (window->priv->thumbview), path);
+		gtk_tree_path_free (path);
+	}
+
+	g_signal_connect (G_OBJECT (store),
+			  "row-inserted",
+			  G_CALLBACK (xviewer_window_list_store_image_added),
+			  window);
+
+	g_signal_connect (G_OBJECT (store),
+			  "row-deleted",
+			  G_CALLBACK (xviewer_window_list_store_image_removed),
+			  window);
+
 	job = xviewer_job_model_new (file_list);
+	XVIEWER_JOB_MODEL (job)->store = store;
 
 	g_signal_connect (job,
 			  "finished",


### PR DESCRIPTION
Fixes #245

This change shows the first image immediately and fills the rest of the gallery model asynchronously. Navigation controls remain disabled until the gallery has meaningful populated state.